### PR TITLE
[codex] Upgrade to Spring Boot 4.0.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.2.4'
-    id 'io.spring.dependency-management' version '1.1.4'
+    id 'org.springframework.boot' version '4.0.6'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'jp.co.solxyz.jsn'
@@ -29,20 +29,11 @@ dependencies {
     implementation 'org.springframework.session:spring-session-core'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
-    implementation 'org.springframework.boot:spring-boot-starter-validation'
-    // https://mvnrepository.com/artifact/org.slf4j/slf4j-api
-    implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.12'
-    // https://mvnrepository.com/artifact/ch.qos.logback/logback-classic
-    testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.4.14'
-    // https://mvnrepository.com/artifact/org.springframework.session/spring-session-jdbc
-    implementation group: 'org.springframework.session', name: 'spring-session-jdbc', version: '3.2.2'
-    // https://mvnrepository.com/artifact/com.fasterxml.jackson.datatype/jackson-datatype-jsr310
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.0'
+    implementation 'org.springframework.session:spring-session-jdbc'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'
-    // https://mvnrepository.com/artifact/org.hibernate/hibernate-validator
-    implementation 'org.hibernate:hibernate-validator:8.0.1.Final'
 
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/jp/co/solxyz/jsn/springbootadvincedexam/config/WebSecurityConfig.java
+++ b/src/main/java/jp/co/solxyz/jsn/springbootadvincedexam/config/WebSecurityConfig.java
@@ -53,9 +53,7 @@ public class WebSecurityConfig {
      */
     @Bean
     public RoleHierarchy roleHierarchy() {
-        RoleHierarchyImpl roleHierarchy = new RoleHierarchyImpl();
         String hierarchy = "ROLE_ADMIN > ROLE_USER";
-        roleHierarchy.setHierarchy(hierarchy);
-        return roleHierarchy;
+        return RoleHierarchyImpl.fromHierarchy(hierarchy);
     }
 }

--- a/src/test/java/jp/co/solxyz/jsn/springbootadvincedexam/app/user/book/controller/BookCartControllerTest.java
+++ b/src/test/java/jp/co/solxyz/jsn/springbootadvincedexam/app/user/book/controller/BookCartControllerTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -36,10 +36,10 @@ import static org.springframework.security.test.web.servlet.setup.SecurityMockMv
 @SpringBootTest
 class BookCartControllerTest {
 
-    @MockBean
+    @MockitoBean
     private CartSession cartSession;
 
-    @MockBean
+    @MockitoBean
     private BookCartService bookCartService;
 
     @Mock

--- a/src/test/java/jp/co/solxyz/jsn/springbootadvincedexam/app/user/book/controller/BookListControllerTest.java
+++ b/src/test/java/jp/co/solxyz/jsn/springbootadvincedexam/app/user/book/controller/BookListControllerTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockitoAnnotations;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -36,7 +36,7 @@ class BookListControllerTest {
 
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private BookListService bookListService;
 
     private final WebApplicationContext context;

--- a/src/test/java/jp/co/solxyz/jsn/springbootadvincedexam/app/user/book/controller/BookReturnControllerTest.java
+++ b/src/test/java/jp/co/solxyz/jsn/springbootadvincedexam/app/user/book/controller/BookReturnControllerTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -30,7 +30,7 @@ import static org.springframework.security.test.web.servlet.setup.SecurityMockMv
 @SpringBootTest
 class BookReturnControllerTest {
 
-    @MockBean
+    @MockitoBean
     private BookLendingService bookLendingService;
 
     @Mock

--- a/src/test/java/jp/co/solxyz/jsn/springbootadvincedexam/component/book/BookLendingManagerTest.java
+++ b/src/test/java/jp/co/solxyz/jsn/springbootadvincedexam/component/book/BookLendingManagerTest.java
@@ -340,8 +340,6 @@ public class BookLendingManagerTest {
     @Test
     @DisplayName("チェックアウト履歴の登録に失敗した場合、DataAccessExceptionのサブクラスが発生する")
     void shouldThrowDataAccessExceptionWhenFailedToSaveCheckoutHistory() {
-        String stringUUID = "00000000-0000-0000-0000-000000000000";
-        UUID uuid = UUID.fromString(stringUUID);
         String userId = "userId";
 
         Book expectedBook = new Book();
@@ -368,42 +366,22 @@ public class BookLendingManagerTest {
         book.setUpdatedAt(TEST_TIME);
         List<Book> rentalTargetBookList = List.of(book);
 
-        BookCheckoutHistory expectedCheckoutHistory = new BookCheckoutHistory();
-        expectedCheckoutHistory.setRentalId(stringUUID);
-        expectedCheckoutHistory.setUserId(userId);
-        expectedCheckoutHistory.setIsbn("1234567890123");
-        expectedCheckoutHistory.setRentalAt(TEST_TIME);
-        List<BookCheckoutHistory> expectedCheckoutHistoryList = List.of(expectedCheckoutHistory);
-
-        BookCheckoutHistory checkoutHistory = new BookCheckoutHistory();
-        checkoutHistory.setRentalId(stringUUID);
-        checkoutHistory.setUserId(userId);
-        checkoutHistory.setIsbn("1234567890123");
-        checkoutHistory.setRentalAt(TEST_TIME);
-        List<BookCheckoutHistory> rentalTargetCheckoutHistoryList = List.of(checkoutHistory);
-
         List<String> isbnList = List.of(book.getIsbn());
 
         when(bookRepository.findAllById(isbnList)).thenReturn(rentalTargetBookList);
         when(bookRepository.saveAll(rentalTargetBookList)).thenReturn(rentalTargetBookList);
         when(bookCheckoutHistoryRepository.findUnreturnedBooksByUserId(userId)).thenReturn(Collections.emptyList());
-        when(bookCheckoutHistoryRepository.saveAll(rentalTargetCheckoutHistoryList)).thenThrow(
+        when(bookCheckoutHistoryRepository.saveAll(any())).thenThrow(
                 new DataAccessResourceFailureException("DBへの接続ができませんでした。"));
 
-        try (MockedStatic<UUID> mockUUID = Mockito.mockStatic(UUID.class);
-                MockedStatic<LocalDateTime> mockLocalDateTime = Mockito.mockStatic(LocalDateTime.class)) {
-            mockUUID.when(UUID::randomUUID).thenReturn(uuid);
-            mockLocalDateTime.when(LocalDateTime::now).thenReturn(TEST_TIME);
-
-            assertThatThrownBy(() -> bookLendingManager.checkout(userId, List.of(book.getIsbn())))
-                    .isInstanceOf(DataAccessException.class)
-                    .hasMessageContaining("DBへの接続ができませんでした。");
-        }
+        assertThatThrownBy(() -> bookLendingManager.checkout(userId, List.of(book.getIsbn())))
+                .isInstanceOf(DataAccessException.class)
+                .hasMessageContaining("DBへの接続ができませんでした。");
 
         verify(bookRepository, times(1)).findAllById(isbnList);
         verify(bookRepository, times(1)).saveAll(expectedBookList);
         verify(bookCheckoutHistoryRepository, times(1)).findUnreturnedBooksByUserId(userId);
-        verify(bookCheckoutHistoryRepository, times(1)).saveAll(expectedCheckoutHistoryList);
+        verify(bookCheckoutHistoryRepository, times(1)).saveAll(any());
     }
 
     @Test

--- a/src/test/java/jp/co/solxyz/jsn/springbootadvincedexam/component/book/BookLendingManagerTest.java
+++ b/src/test/java/jp/co/solxyz/jsn/springbootadvincedexam/component/book/BookLendingManagerTest.java
@@ -8,6 +8,7 @@ import jp.co.solxyz.jsn.springbootadvincedexam.infra.reposiroty.book.BookReposit
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
@@ -28,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -340,6 +342,8 @@ public class BookLendingManagerTest {
     @Test
     @DisplayName("チェックアウト履歴の登録に失敗した場合、DataAccessExceptionのサブクラスが発生する")
     void shouldThrowDataAccessExceptionWhenFailedToSaveCheckoutHistory() {
+        String stringUUID = "00000000-0000-0000-0000-000000000000";
+        UUID uuid = UUID.fromString(stringUUID);
         String userId = "userId";
 
         Book expectedBook = new Book();
@@ -366,22 +370,55 @@ public class BookLendingManagerTest {
         book.setUpdatedAt(TEST_TIME);
         List<Book> rentalTargetBookList = List.of(book);
 
+        BookCheckoutHistory expectedCheckoutHistory = new BookCheckoutHistory();
+        expectedCheckoutHistory.setRentalId(stringUUID);
+        expectedCheckoutHistory.setUserId(userId);
+        expectedCheckoutHistory.setIsbn(book.getIsbn());
+
         List<String> isbnList = List.of(book.getIsbn());
 
         when(bookRepository.findAllById(isbnList)).thenReturn(rentalTargetBookList);
         when(bookRepository.saveAll(rentalTargetBookList)).thenReturn(rentalTargetBookList);
         when(bookCheckoutHistoryRepository.findUnreturnedBooksByUserId(userId)).thenReturn(Collections.emptyList());
-        when(bookCheckoutHistoryRepository.saveAll(any())).thenThrow(
+        when(bookCheckoutHistoryRepository.saveAll(argThat((List<BookCheckoutHistory> histories) -> {
+            if (histories.size() != 1) {
+                return false;
+            }
+            BookCheckoutHistory history = histories.get(0);
+            return stringUUID.equals(history.getRentalId())
+                    && userId.equals(history.getUserId())
+                    && book.getIsbn().equals(history.getIsbn())
+                    && history.getRentalAt() != null;
+        }))).thenThrow(
                 new DataAccessResourceFailureException("DBへの接続ができませんでした。"));
 
-        assertThatThrownBy(() -> bookLendingManager.checkout(userId, List.of(book.getIsbn())))
-                .isInstanceOf(DataAccessException.class)
-                .hasMessageContaining("DBへの接続ができませんでした。");
+        LocalDateTime beforeCheckout = LocalDateTime.now();
+        try (MockedStatic<UUID> mockUUID = Mockito.mockStatic(UUID.class)) {
+            mockUUID.when(UUID::randomUUID).thenReturn(uuid);
+
+            assertThatThrownBy(() -> bookLendingManager.checkout(userId, List.of(book.getIsbn())))
+                    .isInstanceOf(DataAccessException.class)
+                    .hasMessageContaining("DBへの接続ができませんでした。");
+        }
+        LocalDateTime afterCheckout = LocalDateTime.now();
 
         verify(bookRepository, times(1)).findAllById(isbnList);
         verify(bookRepository, times(1)).saveAll(expectedBookList);
         verify(bookCheckoutHistoryRepository, times(1)).findUnreturnedBooksByUserId(userId);
-        verify(bookCheckoutHistoryRepository, times(1)).saveAll(any());
+
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        ArgumentCaptor<List<BookCheckoutHistory>> checkoutHistoriesCaptor =
+                ArgumentCaptor.forClass((Class) List.class);
+        verify(bookCheckoutHistoryRepository, times(1)).saveAll(checkoutHistoriesCaptor.capture());
+
+        List<BookCheckoutHistory> savedCheckoutHistories = checkoutHistoriesCaptor.getValue();
+        assertThat(savedCheckoutHistories).hasSize(1);
+        BookCheckoutHistory savedCheckoutHistory = savedCheckoutHistories.get(0);
+        assertThat(savedCheckoutHistory)
+                .usingRecursiveComparison()
+                .ignoringFields("rentalAt")
+                .isEqualTo(expectedCheckoutHistory);
+        assertThat(savedCheckoutHistory.getRentalAt()).isBetween(beforeCheckout, afterCheckout);
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Upgrade Spring Boot from 3.2.4 to 4.0.6.
- Update Gradle wrapper to 8.14.4 and dependency-management plugin to 1.1.7.
- Align managed dependencies with the Spring Boot BOM.
- Update Spring Security 7 and Spring Boot 4 test APIs.

## Impact

This keeps the training app on the latest stable Spring Boot 4 line while avoiding stale pinned dependency versions that can conflict with the Boot-managed stack.

## Validation

- `GRADLE_USER_HOME=/private/tmp/codex-gradle ./gradlew test`
- `GRADLE_USER_HOME=/private/tmp/codex-gradle ./gradlew bootJar`
