### PR TITLE
[codex] カート画面を刷新

### DIFF
--- a/src/main/java/jp/co/solxyz/jsn/springbootadvincedexam/app/user/book/controller/BookCartController.java
+++ b/src/main/java/jp/co/solxyz/jsn/springbootadvincedexam/app/user/book/controller/BookCartController.java
@@ -15,7 +15,11 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.ModelAndView;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.TextStyle;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * カートコントローラ
@@ -24,6 +28,11 @@ import java.util.List;
 @Slf4j
 @RequestMapping("/book/cart")
 public class BookCartController {
+
+    /**
+     * 返却期限までの日数
+     */
+    private static final int RETURN_DUE_DAYS = 14;
 
     /**
      * カートセッション
@@ -53,7 +62,7 @@ public class BookCartController {
         ModelAndView mav = new ModelAndView("user/book-cart");
         List<CartBookModel> tableData = bookCartService.getCartList(cartSession.getCartList());
         mav.addObject("cartList", tableData);
-        mav.addObject("activeMenu", "cart");
+        addCartPageAttributes(mav, tableData.size());
         return mav;
     }
 
@@ -70,7 +79,7 @@ public class BookCartController {
         } catch (DataAccessException e) {
             ModelAndView mav = new ModelAndView("user/book-cart");
             mav.addObject("errorMessage", "処理中にエラーが発生しました。");
-            mav.addObject("activeMenu", "cart");
+            addCartPageAttributes(mav, cartSession.getCartList().size());
             return mav;
         }
 
@@ -81,7 +90,7 @@ public class BookCartController {
         cartSession.clearCart();
 
         ModelAndView mav = new ModelAndView("user/book-cart");
-        mav.addObject("activeMenu", "cart");
+        addCartPageAttributes(mav, displayedUnCheckedOutBookModels.size());
 
         if (!unCheckedOutBooks.isEmpty()) {
             mav.addObject("errorMessage", "以下の書籍は既に借りている 又は 在庫が不足しているため借りることができません。");
@@ -89,6 +98,18 @@ public class BookCartController {
         }
 
         return mav;
+    }
+
+    private void addCartPageAttributes(ModelAndView mav, int cartCount) {
+        mav.addObject("activeMenu", "cart");
+        mav.addObject("cartCount", cartCount);
+        mav.addObject("returnDueDays", RETURN_DUE_DAYS);
+        mav.addObject("returnDueDateText", formatReturnDueDate(LocalDate.now().plusDays(RETURN_DUE_DAYS)));
+    }
+
+    private String formatReturnDueDate(LocalDate returnDueDate) {
+        String dayOfWeek = returnDueDate.getDayOfWeek().getDisplayName(TextStyle.SHORT, Locale.JAPANESE);
+        return returnDueDate.format(DateTimeFormatter.ofPattern("yyyy/MM/dd")) + " (" + dayOfWeek + ")";
     }
 
 }

--- a/src/main/java/jp/co/solxyz/jsn/springbootadvincedexam/app/user/book/controller/BookCartController.java
+++ b/src/main/java/jp/co/solxyz/jsn/springbootadvincedexam/app/user/book/controller/BookCartController.java
@@ -100,6 +100,11 @@ public class BookCartController {
         return mav;
     }
 
+    /**
+     * カート画面で共通して使用する表示属性を追加する
+     * @param mav モデルとビュー
+     * @param cartCount カート内の書籍数
+     */
     private void addCartPageAttributes(ModelAndView mav, int cartCount) {
         mav.addObject("activeMenu", "cart");
         mav.addObject("cartCount", cartCount);
@@ -107,6 +112,11 @@ public class BookCartController {
         mav.addObject("returnDueDateText", formatReturnDueDate(LocalDate.now().plusDays(RETURN_DUE_DAYS)));
     }
 
+    /**
+     * 返却期限日を画面表示用の形式に変換する
+     * @param returnDueDate 返却期限日
+     * @return 画面表示用の返却期限日
+     */
     private String formatReturnDueDate(LocalDate returnDueDate) {
         String dayOfWeek = returnDueDate.getDayOfWeek().getDisplayName(TextStyle.SHORT, Locale.JAPANESE);
         return returnDueDate.format(DateTimeFormatter.ofPattern("yyyy/MM/dd")) + " (" + dayOfWeek + ")";

--- a/src/main/resources/static/css/cart.css
+++ b/src/main/resources/static/css/cart.css
@@ -1,4 +1,334 @@
-form {
+.cart-screen {
+    min-height: 100vh;
+    background:
+        radial-gradient(circle at 92% 12%, rgba(47, 100, 229, 0.06), transparent 28%),
+        linear-gradient(135deg, #f9fbff 0%, #eef5ff 50%, #f8fbff 100%);
+}
+
+.cart-main {
+    width: min(1190px, calc(100vw - 394px));
+    margin: 48px 64px 34px 330px;
+}
+
+.cart-heading {
+    margin-bottom: 28px;
+}
+
+.cart-heading-title {
+    display: flex;
+    align-items: center;
+    gap: 18px;
+    color: #2f64e5;
+}
+
+.cart-heading-title svg {
+    width: 34px;
+    height: 34px;
+    flex: 0 0 auto;
+}
+
+.cart-heading h1 {
+    margin: 0;
+    color: #162033;
+    font-size: 34px;
+    line-height: 1.25;
+    font-weight: 800;
+}
+
+.cart-heading p {
+    margin: 8px 0 0;
+    color: #5f6f85;
+    font-size: 16px;
+    font-weight: 600;
+}
+
+.cart-alert {
+    margin: 0 0 20px;
+}
+
+.cart-card {
+    padding: 32px 34px 28px;
+    background: rgba(255, 255, 255, 0.96);
+    border: 1px solid #edf2f8;
+    border-radius: 8px;
+    box-shadow: 0 16px 36px rgba(25, 46, 86, 0.12);
+}
+
+.cart-card h2 {
+    margin: 0 0 26px;
+    color: #162033;
+    font-size: 20px;
+    line-height: 1.35;
+    font-weight: 800;
+}
+
+.cart-empty-state {
+    margin: 0;
+    padding: 32px 0;
+    color: #5f6f85;
+    font-size: 16px;
+    font-weight: 700;
+    text-align: center;
+}
+
+.cart-table-wrap {
+    overflow-x: auto;
+}
+
+.cart-table {
+    min-width: 920px;
+    border-collapse: collapse;
+    color: #536176;
+    font-size: 15px;
+}
+
+.cart-table .table-header {
+    color: #2a3446;
+    background: rgba(247, 250, 253, 0.96);
+    font-size: 14px;
+    text-transform: none;
+}
+
+.cart-table .table-header .table-cell {
+    padding-top: 16px;
+    padding-bottom: 16px;
+    font-weight: 800;
+}
+
+.cart-table .table-cell {
+    padding: 24px 12px;
+    vertical-align: middle;
+}
+
+.cart-row {
+    background: #ffffff;
+    border-bottom: 1px solid #e5e7eb;
+}
+
+.cart-book-cell {
+    display: grid;
+    grid-template-columns: 86px minmax(250px, 1fr);
+    align-items: center;
+    gap: 24px;
+}
+
+.cart-cover-frame {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 68px;
+    height: 96px;
+    background: #f8fafc;
+    border: 1px solid #edf2f8;
+    box-shadow: 0 8px 18px rgba(25, 46, 86, 0.08);
+    overflow: hidden;
+}
+
+.cart-cover-frame.has-cover .cover-placeholder {
+    display: none;
+}
+
+.cart-book-title-group {
+    display: flex;
+    align-items: center;
+}
+
+.cart-book-title {
+    color: #162033;
+    font-size: 18px;
+    line-height: 1.45;
+    font-weight: 800;
+}
+
+.cart-due {
+    display: inline-flex;
+    flex-direction: column;
+    gap: 9px;
+    font-weight: 700;
+}
+
+.cart-due-days {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    color: #159764;
+}
+
+.cart-due-days svg {
+    width: 18px;
+    height: 18px;
+}
+
+.cart-due-date {
+    color: #536176;
+}
+
+.cart-delete-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    width: auto;
+    max-width: none;
+    min-height: 40px;
+    margin: 0;
+    padding: 0 15px;
+    color: #ef4444;
+    background: #ffffff;
+    border: 1px solid #fecaca;
+    border-radius: 8px;
+    font-size: 14px;
+    font-weight: 800;
+    opacity: 1;
+}
+
+.cart-delete-button:hover {
+    background: #fff5f5;
+}
+
+.cart-delete-button svg {
+    width: 18px;
+    height: 18px;
+}
+
+.cart-total {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 42px;
+    padding: 26px 24px 6px;
+    color: #162033;
+    font-size: 17px;
+    font-weight: 800;
+}
+
+.cart-total strong {
+    font-size: 18px;
+}
+
+.cart-note {
+    display: flex;
+    gap: 16px;
+    margin-top: 24px;
+    padding: 22px 24px;
+    color: #536176;
+    background: rgba(238, 246, 255, 0.82);
+    border: 1px solid #bcd4ff;
+    border-radius: 8px;
+}
+
+.cart-note-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    flex: 0 0 auto;
+    color: #ffffff;
+    background: #2f64e5;
+    border-radius: 999px;
+    font-weight: 800;
+}
+
+.cart-note h2 {
+    margin: 0 0 6px;
+    color: #2f64e5;
+    font-size: 15px;
+    font-weight: 800;
+}
+
+.cart-note p {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 700;
+    line-height: 1.6;
+}
+
+.cart-actions {
     display: flex;
     justify-content: flex-end;
+    align-items: center;
+    gap: 16px;
+    margin-top: 24px;
+}
+
+.cart-actions form {
+    display: contents;
+}
+
+.cart-action-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    width: auto;
+    max-width: none;
+    min-height: 48px;
+    margin: 0;
+    padding: 0 24px;
+    border-radius: 8px;
+    font-size: 16px;
+    font-weight: 800;
+    text-decoration: none;
+    opacity: 1;
+}
+
+.secondary-action {
+    color: #2f64e5;
+    background: #ffffff;
+    border: 1px solid #2f64e5;
+}
+
+.secondary-action:hover {
+    background: #edf4ff;
+}
+
+.primary-action {
+    color: #ffffff;
+    background: #2f64e5;
+    border: 1px solid #2f64e5;
+    box-shadow: 0 8px 18px rgba(47, 100, 229, 0.22);
+}
+
+.primary-action:hover:not(:disabled) {
+    background: #2555cb;
+}
+
+.primary-action:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+}
+
+.primary-action svg {
+    width: 20px;
+    height: 20px;
+}
+
+.cart-page-footer {
+    margin-top: 58px;
+    color: #657387;
+    font-size: 13px;
+    font-weight: 700;
+    text-align: center;
+}
+
+@media (max-width: 960px) {
+    .cart-main {
+        width: auto;
+        margin: 24px 16px 32px;
+    }
+
+    .cart-card {
+        padding: 24px 16px;
+    }
+
+    .cart-actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .cart-action-button {
+        width: 100%;
+    }
 }

--- a/src/main/resources/templates/user/book-cart.html
+++ b/src/main/resources/templates/user/book-cart.html
@@ -1,51 +1,234 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="https://www.thymeleaf.org" lang="ja">
 <head>
-    <title>Spring Security Example </title>
+    <title>書籍管理アプリ - カート</title>
     <link th:href="@{/css/main.css}" rel="stylesheet">
     <link th:href="@{/css/cart.css}" rel="stylesheet">
     <link th:href="@{/css/list.css}" rel="stylesheet">
     <link th:href="@{/css/button.css}" rel="stylesheet">
+
+    <meta name="_csrf" th:content="${_csrf.token}"/>
+    <meta name="_csrf_header" th:content="${_csrf.headerName}"/>
+    <script th:inline="javascript">
+        const csrfToken = document.querySelector('meta[name="_csrf"]').content;
+        const csrfHeader = document.querySelector('meta[name="_csrf_header"]').content;
+        const openBdBatchSize = 20;
+
+        function showCoverPlaceholder(img) {
+            const frame = img.closest('.cart-cover-frame');
+            img.hidden = true;
+            img.removeAttribute('src');
+            img.removeAttribute('alt');
+            frame?.classList.remove('has-cover');
+        }
+
+        function applyCoverImage(img, coverUrl) {
+            if (!coverUrl) {
+                showCoverPlaceholder(img);
+                return;
+            }
+            const frame = img.closest('.cart-cover-frame');
+            img.onerror = () => showCoverPlaceholder(img);
+            img.hidden = false;
+            frame?.classList.add('has-cover');
+            img.src = coverUrl;
+            img.alt = img.getAttribute('data-cover-title') + ' の書影';
+        }
+
+        function updateCartCount(count) {
+            const totalCount = document.getElementById('cart-total-count');
+            const emptyState = document.getElementById('cart-empty-state');
+            const cartTable = document.getElementById('cart-table-wrap');
+            const checkoutButton = document.getElementById('checkout-button');
+
+            document.querySelectorAll('.app-menu-badge').forEach(badge => {
+                badge.textContent = count;
+            });
+            if (totalCount) {
+                totalCount.textContent = `${count}冊`;
+            }
+            if (emptyState) {
+                emptyState.hidden = count !== 0;
+            }
+            if (cartTable) {
+                cartTable.hidden = count === 0;
+            }
+            if (checkoutButton) {
+                checkoutButton.disabled = count === 0;
+            }
+        }
+
+        async function hydrateCartCovers() {
+            const coverImages = Array.from(document.querySelectorAll('[data-cover-isbn]'));
+            const isbnList = coverImages
+                .map(img => img.getAttribute('data-cover-isbn'))
+                .filter(isbn => /^\d{13}$/.test(isbn));
+            if (isbnList.length === 0) {
+                return;
+            }
+
+            for (let index = 0; index < isbnList.length; index += openBdBatchSize) {
+                const batch = isbnList.slice(index, index + openBdBatchSize);
+                try {
+                    const response = await fetch(`/api/book/covers?isbn=${batch.map(encodeURIComponent).join(',')}`);
+                    if (!response.ok) {
+                        throw new Error('cover request failed');
+                    }
+                    const coverUrls = await response.json();
+                    batch.forEach(isbn => {
+                        document.querySelectorAll(`[data-cover-isbn="${isbn}"]`).forEach(img => {
+                            applyCoverImage(img, coverUrls[isbn]);
+                        });
+                    });
+                } catch (error) {
+                    batch.forEach(isbn => {
+                        document.querySelectorAll(`[data-cover-isbn="${isbn}"]`).forEach(showCoverPlaceholder);
+                    });
+                    console.warn('openBDから書影を取得できませんでした。', error);
+                }
+            }
+        }
+
+        function deleteCartBook(isbn) {
+            fetch('/api/book/cart', {
+                method: 'DELETE',
+                headers: {
+                    'Content-Type': 'application/json',
+                    [csrfHeader]: csrfToken
+                },
+                body: JSON.stringify({isbn})
+            }).then(response => {
+                if (!response.ok) {
+                    throw new Error('delete request failed');
+                }
+                const row = document.querySelector(`[data-cart-row="${isbn}"]`);
+                row?.remove();
+                updateCartCount(document.querySelectorAll('[data-cart-row]').length);
+            }).catch(error => {
+                console.error('Error:', error);
+                alert('カートから削除できませんでした');
+            });
+        }
+
+        window.addEventListener('DOMContentLoaded', () => {
+            hydrateCartCovers();
+            document.querySelectorAll('[data-delete-isbn]').forEach(button => {
+                button.addEventListener('click', () => deleteCartBook(button.getAttribute('data-delete-isbn')));
+            });
+            updateCartCount(document.querySelectorAll('[data-cart-row]').length);
+        });
+    </script>
 </head>
-<body>
+<body class="cart-screen">
 
 <div id="header"
      th:replace="~{common/nav-bar :: bar}"></div>
-<div class="page-alert" th:if="${errorMessage}">
-    <div class="alert alert-danger" role="alert">
-        <svg class="alert-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor"
-             viewBox="0 0 20 20">
-            <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM9.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM12 15H8a1 1 0 0 1 0-2h1v-3H8a1 1 0 0 1 0-2h2a1 1 0 0 1 1 1v4h1a1 1 0 0 1 0 2Z"/>
-        </svg>
-        <span class="sr-only">Info</span>
-        <div class="alert-content">
-            <span class="alert-title" th:text="${errorMessage}"></span>
+
+<main class="cart-main">
+    <section class="cart-heading">
+        <div class="cart-heading-title">
+            <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+                <path d="M4.5 5.25h2l1.6 9.2a2 2 0 0 0 1.97 1.65h6.75a2 2 0 0 0 1.95-1.56l1.02-4.54H8" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+                <path d="M10 20.25h.01M17 20.25h.01" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+            </svg>
+            <h1>カート</h1>
+        </div>
+        <p>借りたい書籍の一覧です。内容を確認して、手続きを進めましょう。</p>
+    </section>
+
+    <div class="page-alert cart-alert" th:if="${errorMessage}">
+        <div class="alert alert-danger" role="alert">
+            <svg class="alert-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor"
+                 viewBox="0 0 20 20">
+                <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM9.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM12 15H8a1 1 0 0 1 0-2h1v-3H8a1 1 0 0 1 0-2h2a1 1 0 0 1 1 1v4h1a1 1 0 0 1 0 2Z"/>
+            </svg>
+            <span class="sr-only">Info</span>
+            <div class="alert-content">
+                <span class="alert-title" th:text="${errorMessage}"></span>
+            </div>
         </div>
     </div>
-</div>
-<div class="table-container">
-    <table id="book-table" class="table">
-        <thead class="table-header">
-        <tr>
-            <th scope="col" class="table-cell">書籍名</th>
-            <th scope="col" class="table-cell">出版社</th>
-            <th scope="col" class="table-cell">著者名</th>
-        </tr>
-        </thead>
 
-        <tbody>
-        <tr th:each="book : ${cartList}" class="table-row">
-            <th scope="row" class="table-cell font-medium" th:text="${book.title}"></th>
-            <td class="table-cell" th:text="${book.publisher}"></td>
-            <td class="table-cell" th:text="${book.author}"></td>
-        </tr>
-        </tbody>
+    <section class="cart-card">
+        <h2>カートに入っている書籍</h2>
+        <p id="cart-empty-state" class="cart-empty-state" th:hidden="${cartCount != 0}">カートに書籍は入っていません。</p>
+        <div id="cart-table-wrap" class="cart-table-wrap" th:hidden="${cartCount == 0}">
+            <table id="book-table" class="table cart-table">
+                <thead class="table-header">
+                <tr>
+                    <th scope="col" class="table-cell">書籍</th>
+                    <th scope="col" class="table-cell">出版社</th>
+                    <th scope="col" class="table-cell">著者</th>
+                    <th scope="col" class="table-cell">返却期限の目安</th>
+                    <th scope="col" class="table-cell">操作</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="book : ${cartList}" class="table-row cart-row" th:attr="data-cart-row=${book.isbn}">
+                    <th scope="row" class="table-cell font-medium cart-book-cell">
+                        <span class="cart-cover-frame">
+                            <img class="book-cover" th:attr="data-cover-isbn=${book.isbn}, data-cover-title=${book.title}" th:alt="${book.title + ' の書影'}" loading="lazy" hidden>
+                            <span class="cover-placeholder" aria-hidden="true">
+                                <span class="cover-placeholder-text">NO IMAGE</span>
+                            </span>
+                        </span>
+                        <span class="cart-book-title-group">
+                            <span class="cart-book-title" th:text="${book.title}"></span>
+                        </span>
+                    </th>
+                    <td class="table-cell" th:text="${book.publisher}"></td>
+                    <td class="table-cell" th:text="${book.author}"></td>
+                    <td class="table-cell">
+                        <span class="cart-due">
+                            <span class="cart-due-days">
+                                <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+                                    <path d="M7 3.75v3M17 3.75v3M4.75 9.25h14.5M6.5 5.25h11A1.75 1.75 0 0 1 19.25 7v10.5a1.75 1.75 0 0 1-1.75 1.75h-11a1.75 1.75 0 0 1-1.75-1.75V7A1.75 1.75 0 0 1 6.5 5.25Z" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+                                </svg>
+                                <span th:text="${returnDueDays + '日後'}">14日後</span>
+                            </span>
+                            <span class="cart-due-date" th:text="${returnDueDateText}">2026/01/01 (木)</span>
+                        </span>
+                    </td>
+                    <td class="table-cell">
+                        <button type="button" class="cart-delete-button" th:attr="data-delete-isbn=${book.isbn}, aria-label=${book.title + ' をカートから削除'}">
+                            <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+                                <path d="M6.75 7.25h10.5M10 7.25v-.9a1.6 1.6 0 0 1 1.6-1.6h.8a1.6 1.6 0 0 1 1.6 1.6v.9M8.25 9.75l.55 8.15a1.5 1.5 0 0 0 1.5 1.35h3.4a1.5 1.5 0 0 0 1.5-1.35l.55-8.15M10.75 11.75v4.5M13.25 11.75v4.5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+                            </svg>
+                            削除
+                        </button>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+            <div class="cart-total">
+                <span>合計</span>
+                <strong id="cart-total-count" th:text="${cartCount + '冊'}">0冊</strong>
+            </div>
+        </div>
+    </section>
 
-    </table>
-    <form th:action="@{/book/cart}" method="post">
-        <button class="rental-button">借りる</button>
-    </form>
-</div>
+    <section class="cart-note" aria-label="返却期限について">
+        <span class="cart-note-icon">i</span>
+        <div>
+            <h2>返却期限について</h2>
+            <p th:text="${'返却期限の目安は、書籍を借りた日から' + returnDueDays + '日後です。期限は延長できませんのでご注意ください。'}"></p>
+        </div>
+    </section>
+
+    <div class="cart-actions">
+        <a class="cart-action-button secondary-action" th:href="@{/book/list}">買い物を続ける</a>
+        <form th:action="@{/book/cart}" method="post">
+            <button id="checkout-button" type="submit" class="cart-action-button primary-action" th:disabled="${cartCount == 0}">
+                借りる手続きへ進む
+                <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+                    <path d="M5.75 12h12.5M13.75 7.5 18.25 12l-4.5 4.5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </button>
+        </form>
+    </div>
+
+    <footer class="cart-page-footer">© 2024 書籍管理アプリ. All rights reserved.</footer>
+</main>
 
 </body>
 </html>

--- a/src/test/java/jp/co/solxyz/jsn/springbootadvincedexam/app/user/book/controller/BookCartControllerTest.java
+++ b/src/test/java/jp/co/solxyz/jsn/springbootadvincedexam/app/user/book/controller/BookCartControllerTest.java
@@ -92,6 +92,9 @@ class BookCartControllerTest {
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.view().name("user/book-cart"))
                 .andExpect(MockMvcResultMatchers.model().attribute("activeMenu", "cart"))
+                .andExpect(MockMvcResultMatchers.model().attribute("cartCount", 1))
+                .andExpect(MockMvcResultMatchers.model().attribute("returnDueDays", 14))
+                .andExpect(MockMvcResultMatchers.model().attributeExists("returnDueDateText"))
                 .andExpect(MockMvcResultMatchers.model().attribute("cartList", expectedCartBooks));
         verify(bookCartService, times(1)).getCartList(expectedCarts);
     }
@@ -119,6 +122,9 @@ class BookCartControllerTest {
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.view().name("user/book-cart"))
                 .andExpect(MockMvcResultMatchers.model().attribute("activeMenu", "cart"))
+                .andExpect(MockMvcResultMatchers.model().attribute("cartCount", 2))
+                .andExpect(MockMvcResultMatchers.model().attribute("returnDueDays", 14))
+                .andExpect(MockMvcResultMatchers.model().attributeExists("returnDueDateText"))
                 .andExpect(MockMvcResultMatchers.model().attribute("cartList", expectedCartBooks));
     }
 
@@ -132,6 +138,9 @@ class BookCartControllerTest {
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.view().name("user/book-cart"))
                 .andExpect(MockMvcResultMatchers.model().attribute("activeMenu", "cart"))
+                .andExpect(MockMvcResultMatchers.model().attribute("cartCount", 0))
+                .andExpect(MockMvcResultMatchers.model().attribute("returnDueDays", 14))
+                .andExpect(MockMvcResultMatchers.model().attributeExists("returnDueDateText"))
                 .andExpect(MockMvcResultMatchers.model().attribute("cartList", Collections.emptyList()));
 
         verify(bookCartService, times(1)).getCartList(Collections.emptyList());
@@ -155,6 +164,9 @@ class BookCartControllerTest {
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.view().name("user/book-cart"))
                 .andExpect(MockMvcResultMatchers.model().attribute("activeMenu", "cart"))
+                .andExpect(MockMvcResultMatchers.model().attribute("cartCount", 0))
+                .andExpect(MockMvcResultMatchers.model().attribute("returnDueDays", 14))
+                .andExpect(MockMvcResultMatchers.model().attributeExists("returnDueDateText"))
                 .andExpect(MockMvcResultMatchers.model().attributeDoesNotExist("cartList"));
 
         verify(bookCartService, times(1)).checkout(expectedUserId, List.of(cart));
@@ -178,6 +190,9 @@ class BookCartControllerTest {
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.view().name("user/book-cart"))
                 .andExpect(MockMvcResultMatchers.model().attribute("activeMenu", "cart"))
+                .andExpect(MockMvcResultMatchers.model().attribute("cartCount", 1))
+                .andExpect(MockMvcResultMatchers.model().attribute("returnDueDays", 14))
+                .andExpect(MockMvcResultMatchers.model().attributeExists("returnDueDateText"))
                 .andExpect(MockMvcResultMatchers.model().attribute("errorMessage", "処理中にエラーが発生しました。"));
 
         verify(bookCartService, times(1)).checkout(expectedUserId, List.of(cart));
@@ -211,6 +226,9 @@ class BookCartControllerTest {
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.view().name("user/book-cart"))
                 .andExpect(MockMvcResultMatchers.model().attribute("activeMenu", "cart"))
+                .andExpect(MockMvcResultMatchers.model().attribute("cartCount", 1))
+                .andExpect(MockMvcResultMatchers.model().attribute("returnDueDays", 14))
+                .andExpect(MockMvcResultMatchers.model().attributeExists("returnDueDateText"))
                 .andExpect(MockMvcResultMatchers.model().attribute("cartList", expectedCartBooks))
                 .andExpect(MockMvcResultMatchers.model().attribute("errorMessage", "以下の書籍は既に借りている 又は 在庫が不足しているため借りることができません。"));
 
@@ -257,6 +275,9 @@ class BookCartControllerTest {
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.view().name("user/book-cart"))
                 .andExpect(MockMvcResultMatchers.model().attribute("activeMenu", "cart"))
+                .andExpect(MockMvcResultMatchers.model().attribute("cartCount", 2))
+                .andExpect(MockMvcResultMatchers.model().attribute("returnDueDays", 14))
+                .andExpect(MockMvcResultMatchers.model().attributeExists("returnDueDateText"))
                 .andExpect(MockMvcResultMatchers.model().attribute("cartList", expectedCartBooks))
                 .andExpect(MockMvcResultMatchers.model().attribute("errorMessage", "以下の書籍は既に借りている 又は 在庫が不足しているため借りることができません。"));
 


### PR DESCRIPTION
## Summary
- カート画面をスクリーンショットに合わせたカード型レイアウトへ刷新
- カート内の書籍にopenBD書影、NO IMAGE、返却期限目安、削除ボタン、合計表示を追加
- 表示用のカート件数と返却期限属性をControllerに追加し、Controllerテストを更新

## Validation
- ./gradlew test
- git diff --check
- ローカル起動後にログインし、空カートと1冊入りカートのHTML描画を確認