### PR TITLE
[codex] 借りている書籍画面を刷新

### DIFF
--- a/src/main/java/jp/co/solxyz/jsn/springbootadvincedexam/app/user/book/constant/BookLendingPolicy.java
+++ b/src/main/java/jp/co/solxyz/jsn/springbootadvincedexam/app/user/book/constant/BookLendingPolicy.java
@@ -1,0 +1,18 @@
+package jp.co.solxyz.jsn.springbootadvincedexam.app.user.book.constant;
+
+/**
+ * 書籍貸出ポリシー
+ */
+public final class BookLendingPolicy {
+
+    /**
+     * 返却期限までの日数
+     */
+    public static final int RETURN_DUE_DAYS = 14;
+
+    /**
+     * インスタンス化を防ぐコンストラクタ
+     */
+    private BookLendingPolicy() {
+    }
+}

--- a/src/main/java/jp/co/solxyz/jsn/springbootadvincedexam/app/user/book/controller/BookCartController.java
+++ b/src/main/java/jp/co/solxyz/jsn/springbootadvincedexam/app/user/book/controller/BookCartController.java
@@ -21,6 +21,8 @@ import java.time.format.TextStyle;
 import java.util.List;
 import java.util.Locale;
 
+import static jp.co.solxyz.jsn.springbootadvincedexam.app.user.book.constant.BookLendingPolicy.RETURN_DUE_DAYS;
+
 /**
  * カートコントローラ
  */
@@ -28,11 +30,6 @@ import java.util.Locale;
 @Slf4j
 @RequestMapping("/book/cart")
 public class BookCartController {
-
-    /**
-     * 返却期限までの日数
-     */
-    private static final int RETURN_DUE_DAYS = 14;
 
     /**
      * カートセッション

--- a/src/main/java/jp/co/solxyz/jsn/springbootadvincedexam/app/user/book/controller/BookReturnController.java
+++ b/src/main/java/jp/co/solxyz/jsn/springbootadvincedexam/app/user/book/controller/BookReturnController.java
@@ -14,17 +14,14 @@ import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 
+import static jp.co.solxyz.jsn.springbootadvincedexam.app.user.book.constant.BookLendingPolicy.RETURN_DUE_DAYS;
+
 /**
  * 書籍返却コントローラ
  */
 @Controller
 @RequestMapping("/book/return")
 public class BookReturnController {
-    /**
-     * 返却期限までの日数
-     */
-    private static final int RETURN_DUE_DAYS = 14;
-
     /**
      * 返却期限が近いとみなす残日数
      */
@@ -69,7 +66,7 @@ public class BookReturnController {
      */
     private void addLendingPageAttributes(ModelAndView mav, List<UnreturnedBookModel> displayBooks) {
         long dueSoonCount = displayBooks.stream()
-                .filter(book -> book.isDueSoon() || book.isOverdue())
+                .filter(UnreturnedBookModel::isDueSoon)
                 .count();
 
         mav.addObject("activeMenu", "lending");

--- a/src/main/java/jp/co/solxyz/jsn/springbootadvincedexam/app/user/book/controller/BookReturnController.java
+++ b/src/main/java/jp/co/solxyz/jsn/springbootadvincedexam/app/user/book/controller/BookReturnController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.ModelAndView;
 
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
@@ -31,13 +32,19 @@ public class BookReturnController {
      * 書籍返却サービス
      */
     private final BookLendingService bookReturnService;
+    /**
+     * 現在日時取得用Clock
+     */
+    private final Clock clock;
 
     /**
      * コンストラクタ
      * @param bookReturnService 書籍返却サービス
+     * @param clock 現在日時取得用Clock
      */
-    public BookReturnController(BookLendingService bookReturnService) {
+    public BookReturnController(BookLendingService bookReturnService, Clock clock) {
         this.bookReturnService = bookReturnService;
+        this.clock = clock;
     }
 
     /**
@@ -122,7 +129,7 @@ public class BookReturnController {
         if (dueAt == null) {
             return 0;
         }
-        return ChronoUnit.DAYS.between(LocalDate.now(), dueAt.toLocalDate());
+        return ChronoUnit.DAYS.between(LocalDate.now(clock), dueAt.toLocalDate());
     }
 
     /**

--- a/src/main/java/jp/co/solxyz/jsn/springbootadvincedexam/app/user/book/controller/BookReturnController.java
+++ b/src/main/java/jp/co/solxyz/jsn/springbootadvincedexam/app/user/book/controller/BookReturnController.java
@@ -9,6 +9,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.ModelAndView;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 /**
@@ -17,6 +20,16 @@ import java.util.List;
 @Controller
 @RequestMapping("/book/return")
 public class BookReturnController {
+    /**
+     * 返却期限までの日数
+     */
+    private static final int RETURN_DUE_DAYS = 14;
+
+    /**
+     * 返却期限が近いとみなす残日数
+     */
+    private static final int DUE_SOON_DAYS = 3;
+
     /**
      * 書籍返却サービス
      */
@@ -39,9 +52,95 @@ public class BookReturnController {
     public ModelAndView index(@AuthenticationPrincipal MyUserDetails userDetails) {
         ModelAndView mav = new ModelAndView("user/book-lending");
         List<UnreturnedBookModel> unreturnedBooks = bookReturnService.getCurrentUserBooks(userDetails.getUserId());
+        List<UnreturnedBookModel> displayBooks = unreturnedBooks.stream()
+                .map(this::createDisplayBook)
+                .toList();
 
         mav.addObject("books", unreturnedBooks);
-        mav.addObject("activeMenu", "lending");
+        mav.addObject("displayBooks", displayBooks);
+        addLendingPageAttributes(mav, displayBooks);
         return mav;
+    }
+
+    /**
+     * 借りている書籍画面で共通して使用する表示属性を追加する
+     * @param mav モデルとビュー
+     * @param displayBooks 表示用の未返却書籍
+     */
+    private void addLendingPageAttributes(ModelAndView mav, List<UnreturnedBookModel> displayBooks) {
+        long dueSoonCount = displayBooks.stream()
+                .filter(book -> book.isDueSoon() || book.isOverdue())
+                .count();
+
+        mav.addObject("activeMenu", "lending");
+        mav.addObject("bookCount", displayBooks.size());
+        mav.addObject("dueSoonCount", dueSoonCount);
+        mav.addObject("returnDueDays", RETURN_DUE_DAYS);
+    }
+
+    /**
+     * 画面表示用の未返却書籍情報を作成する
+     * @param book 未返却書籍
+     * @return 画面表示用の未返却書籍
+     */
+    private UnreturnedBookModel createDisplayBook(UnreturnedBookModel book) {
+        UnreturnedBookModel displayBook = new UnreturnedBookModel();
+        displayBook.setIsbn(book.getIsbn());
+        displayBook.setTitle(book.getTitle());
+        displayBook.setAuthor(book.getAuthor());
+        displayBook.setPublisher(book.getPublisher());
+        displayBook.setRentalAt(book.getRentalAt());
+
+        LocalDateTime dueAt = calculateDueAt(book.getRentalAt());
+        long remainingDays = calculateRemainingDays(dueAt);
+        boolean overdue = dueAt != null && remainingDays < 0;
+        boolean dueSoon = dueAt != null && !overdue && remainingDays <= DUE_SOON_DAYS;
+
+        displayBook.setDueAt(dueAt);
+        displayBook.setRemainingDays(Math.max(remainingDays, 0));
+        displayBook.setDueSoon(dueSoon);
+        displayBook.setOverdue(overdue);
+        displayBook.setStatusLabel(createStatusLabel(overdue, dueSoon));
+        return displayBook;
+    }
+
+    /**
+     * 貸出日時から返却期限日時を計算する
+     * @param rentalAt 貸出日時
+     * @return 返却期限日時
+     */
+    private LocalDateTime calculateDueAt(LocalDateTime rentalAt) {
+        if (rentalAt == null) {
+            return null;
+        }
+        return rentalAt.plusDays(RETURN_DUE_DAYS);
+    }
+
+    /**
+     * 返却期限日までの残日数を計算する
+     * @param dueAt 返却期限日時
+     * @return 返却期限日までの残日数
+     */
+    private long calculateRemainingDays(LocalDateTime dueAt) {
+        if (dueAt == null) {
+            return 0;
+        }
+        return ChronoUnit.DAYS.between(LocalDate.now(), dueAt.toLocalDate());
+    }
+
+    /**
+     * 貸出ステータスの表示名を作成する
+     * @param overdue 返却期限を過ぎているか
+     * @param dueSoon 返却期限が近いか
+     * @return 貸出ステータスの表示名
+     */
+    private String createStatusLabel(boolean overdue, boolean dueSoon) {
+        if (overdue) {
+            return "期限超過";
+        }
+        if (dueSoon) {
+            return "返却間近";
+        }
+        return "貸出中";
     }
 }

--- a/src/main/java/jp/co/solxyz/jsn/springbootadvincedexam/app/user/book/model/UnreturnedBookModel.java
+++ b/src/main/java/jp/co/solxyz/jsn/springbootadvincedexam/app/user/book/model/UnreturnedBookModel.java
@@ -19,4 +19,14 @@ public class UnreturnedBookModel {
     private String publisher;
     /** 貸出日時 */
     private LocalDateTime rentalAt;
+    /** 返却期限日時 */
+    private LocalDateTime dueAt;
+    /** 返却期限までの日数 */
+    private long remainingDays;
+    /** 返却期限が近いか */
+    private boolean dueSoon;
+    /** 返却期限を過ぎているか */
+    private boolean overdue;
+    /** 貸出ステータス表示名 */
+    private String statusLabel;
 }

--- a/src/main/java/jp/co/solxyz/jsn/springbootadvincedexam/config/ClockConfig.java
+++ b/src/main/java/jp/co/solxyz/jsn/springbootadvincedexam/config/ClockConfig.java
@@ -1,0 +1,22 @@
+package jp.co.solxyz.jsn.springbootadvincedexam.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+
+/**
+ * 時刻取得設定クラス
+ */
+@Configuration
+public class ClockConfig {
+
+    /**
+     * システム標準タイムゾーンのClockを生成する
+     * @return Clock
+     */
+    @Bean
+    public Clock clock() {
+        return Clock.systemDefaultZone();
+    }
+}

--- a/src/main/resources/static/css/lending.css
+++ b/src/main/resources/static/css/lending.css
@@ -1,0 +1,400 @@
+.lending-screen {
+    min-height: 100vh;
+    background:
+        radial-gradient(circle at 88% 12%, rgba(47, 100, 229, 0.06), transparent 30%),
+        linear-gradient(135deg, #f9fbff 0%, #eef5ff 50%, #f8fbff 100%);
+}
+
+.lending-main {
+    width: min(1190px, calc(100vw - 394px));
+    margin: 56px 64px 44px 330px;
+}
+
+.lending-heading {
+    margin-bottom: 34px;
+}
+
+.lending-heading-title {
+    display: flex;
+    align-items: center;
+    gap: 18px;
+}
+
+.lending-heading-icon,
+.lending-summary-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    color: #2f64e5;
+    background: #edf4ff;
+    border-radius: 999px;
+}
+
+.lending-heading-icon {
+    width: 54px;
+    height: 54px;
+}
+
+.lending-heading-icon svg {
+    width: 30px;
+    height: 30px;
+}
+
+.lending-heading h1 {
+    margin: 0;
+    color: #162033;
+    font-size: 34px;
+    line-height: 1.25;
+    font-weight: 800;
+}
+
+.lending-heading p {
+    margin: 10px 0 0 72px;
+    color: #5f6f85;
+    font-size: 16px;
+    font-weight: 700;
+}
+
+.lending-summary-card {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0;
+    margin-bottom: 34px;
+    padding: 28px 36px;
+    background: rgba(255, 255, 255, 0.96);
+    border: 1px solid #edf2f8;
+    border-radius: 8px;
+    box-shadow: 0 16px 36px rgba(25, 46, 86, 0.12);
+}
+
+.lending-summary-item {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 24px;
+    min-height: 96px;
+}
+
+.lending-summary-item + .lending-summary-item {
+    border-left: 1px solid #dce6f4;
+}
+
+.lending-summary-icon {
+    width: 64px;
+    height: 64px;
+}
+
+.lending-summary-icon svg {
+    width: 32px;
+    height: 32px;
+}
+
+.lending-summary-label {
+    display: block;
+    margin-bottom: 8px;
+    color: #536176;
+    font-size: 14px;
+    font-weight: 800;
+}
+
+.lending-summary-item strong {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 12px;
+    color: #2f64e5;
+    font-size: 38px;
+    line-height: 1;
+    font-weight: 800;
+}
+
+.lending-summary-item strong span:last-child {
+    color: #162033;
+    font-size: 17px;
+}
+
+.lending-card {
+    background: rgba(255, 255, 255, 0.96);
+    border: 1px solid #edf2f8;
+    border-radius: 8px;
+    box-shadow: 0 16px 36px rgba(25, 46, 86, 0.12);
+    overflow: hidden;
+}
+
+.lending-empty-state {
+    margin: 0;
+    padding: 48px 24px;
+    color: #5f6f85;
+    font-size: 16px;
+    font-weight: 800;
+    text-align: center;
+}
+
+.lending-table-wrap {
+    overflow-x: auto;
+}
+
+.lending-table {
+    min-width: 1080px;
+    border-collapse: collapse;
+    color: #536176;
+    font-size: 15px;
+}
+
+.lending-table .table-header {
+    color: #2a3446;
+    background: rgba(247, 250, 253, 0.96);
+    font-size: 14px;
+    text-transform: none;
+}
+
+.lending-table .table-header .table-cell {
+    padding-top: 20px;
+    padding-bottom: 20px;
+    font-weight: 800;
+}
+
+.lending-table .table-cell {
+    padding: 30px 12px;
+    vertical-align: middle;
+}
+
+.lending-row {
+    background: #ffffff;
+    border-bottom: 1px solid #e5e7eb;
+}
+
+.lending-book-cell {
+    display: grid;
+    grid-template-columns: 96px minmax(170px, 1fr);
+    align-items: center;
+    gap: 24px;
+}
+
+.lending-cover-frame {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 82px;
+    height: 118px;
+    background: #f8fafc;
+    border: 1px solid #edf2f8;
+    box-shadow: 0 8px 18px rgba(25, 46, 86, 0.08);
+    overflow: hidden;
+}
+
+.lending-cover-frame.has-cover .cover-placeholder {
+    display: none;
+}
+
+.lending-book-title-group {
+    display: flex;
+    align-items: center;
+}
+
+.lending-book-title {
+    color: #162033;
+    font-size: 18px;
+    line-height: 1.55;
+    font-weight: 800;
+}
+
+.lending-date,
+.lending-due {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    color: #25324a;
+    font-weight: 800;
+}
+
+.lending-date svg {
+    width: 17px;
+    height: 17px;
+    color: #536176;
+}
+
+.lending-time {
+    display: block;
+    margin-top: 8px;
+    color: #536176;
+    font-weight: 700;
+}
+
+.lending-due {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.lending-due .lending-date {
+    color: #25324a;
+}
+
+.lending-remaining {
+    color: #16a060;
+    font-weight: 800;
+}
+
+.lending-remaining.is-due-soon {
+    color: #d97706;
+}
+
+.lending-remaining.is-overdue {
+    color: #dc2626;
+}
+
+.lending-status {
+    display: inline-flex;
+    align-items: center;
+    min-height: 28px;
+    padding: 4px 12px;
+    color: #159764;
+    background: #dff8e9;
+    border-radius: 8px;
+    font-size: 14px;
+    font-weight: 800;
+}
+
+.lending-status.is-due-soon {
+    color: #b45309;
+    background: #fef3c7;
+}
+
+.lending-status.is-overdue {
+    color: #dc2626;
+    background: #fee2e2;
+}
+
+.lending-return-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    width: auto;
+    max-width: none;
+    min-height: 42px;
+    margin: 0;
+    padding: 0 16px;
+    color: #25324a;
+    background: #ffffff;
+    border: 1px solid #b9c7dc;
+    border-radius: 8px;
+    font-size: 14px;
+    font-weight: 800;
+    opacity: 1;
+}
+
+.lending-return-button:hover {
+    color: #2f64e5;
+    border-color: #2f64e5;
+    background: #edf4ff;
+}
+
+.lending-return-button svg {
+    width: 18px;
+    height: 18px;
+}
+
+.lending-pagination {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 14px;
+    padding: 34px 24px;
+}
+
+.lending-pagination button,
+.lending-pagination span {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    margin: 0;
+    border-radius: 8px;
+    font-weight: 800;
+}
+
+.lending-pagination button {
+    max-width: none;
+    color: #8fa0b7;
+    background: #f8fafc;
+    border: 1px solid #dce6f4;
+    opacity: 0.55;
+}
+
+.lending-pagination button svg {
+    width: 20px;
+    height: 20px;
+}
+
+.lending-pagination span {
+    color: #2f64e5;
+    background: #edf4ff;
+    border: 1px solid #a9c4ff;
+}
+
+.lending-note {
+    display: flex;
+    gap: 16px;
+    margin-top: 24px;
+    padding: 22px 24px;
+    color: #536176;
+    background: rgba(238, 246, 255, 0.82);
+    border: 1px solid #bcd4ff;
+    border-radius: 8px;
+}
+
+.lending-note-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    flex: 0 0 auto;
+    color: #ffffff;
+    background: #2f64e5;
+    border-radius: 999px;
+    font-weight: 800;
+}
+
+.lending-note h2 {
+    margin: 0 0 6px;
+    color: #2f64e5;
+    font-size: 15px;
+    font-weight: 800;
+}
+
+.lending-note p {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 700;
+    line-height: 1.6;
+}
+
+@media (max-width: 960px) {
+    .lending-main {
+        width: auto;
+        margin: 24px 16px 32px;
+    }
+
+    .lending-heading p {
+        margin-left: 0;
+    }
+
+    .lending-summary-card {
+        grid-template-columns: 1fr;
+        padding: 20px;
+    }
+
+    .lending-summary-item {
+        justify-content: flex-start;
+    }
+
+    .lending-summary-item + .lending-summary-item {
+        border-top: 1px solid #dce6f4;
+        border-left: 0;
+    }
+}

--- a/src/main/resources/templates/user/book-lending.html
+++ b/src/main/resources/templates/user/book-lending.html
@@ -2,78 +2,263 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="https://www.thymeleaf.org" lang="ja">
 
 <head>
-    <title>書籍管理アプリ - レンタル中</title>
+    <title>書籍管理アプリ - 借りている書籍</title>
     <link th:href="@{/css/main.css}" rel="stylesheet">
     <link th:href="@{/css/list.css}" rel="stylesheet">
-    <link rel="stylesheet"
-          href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
+    <link th:href="@{/css/lending.css}" rel="stylesheet">
+    <link th:href="@{/css/button.css}" rel="stylesheet">
 
     <meta name="_csrf" th:content="${_csrf.token}"/>
     <meta name="_csrf_header" th:content="${_csrf.headerName}"/>
 
     <script th:inline="javascript">
-/*<![CDATA[*/
-const books = JSON.parse(/*[[ ${booksJson} ]]*/ null);
-/*]]>*/
+        const csrfToken = document.querySelector('meta[name="_csrf"]').content;
+        const csrfHeader = document.querySelector('meta[name="_csrf_header"]').content;
+        const openBdBatchSize = 20;
 
-const csrfToken = document.querySelector('meta[name="_csrf"]').content;
-const csrfHeader = document.querySelector('meta[name="_csrf_header"]').content;
+        function showCoverPlaceholder(img) {
+            const frame = img.closest('.lending-cover-frame');
+            img.hidden = true;
+            img.removeAttribute('src');
+            img.removeAttribute('alt');
+            frame?.classList.remove('has-cover');
+        }
 
-function returnBook(event) {
-  const isbn = event.target.getAttribute("data-isbn");
-  fetch("/api/book/return", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      [csrfHeader]: csrfToken,
-    },
-    body: JSON.stringify({
-      isbn: isbn,
-    }),
-  })
-    .then((response) => {
-      if (response.ok) {
-        alert("書籍を返却しました");
-        location.reload();
-      } else {
-        alert("書籍の返却に失敗しました");
-      }
-    })
-    .catch((error) => {
-      console.error("Error:", error);
-    });
-}
+        function applyCoverImage(img, coverUrl) {
+            if (!coverUrl) {
+                showCoverPlaceholder(img);
+                return;
+            }
+            const frame = img.closest('.lending-cover-frame');
+            img.onerror = () => showCoverPlaceholder(img);
+            img.hidden = false;
+            frame?.classList.add('has-cover');
+            img.src = coverUrl;
+            img.alt = img.getAttribute('data-cover-title') + ' の書影';
+        }
 
+        async function hydrateLendingCovers() {
+            const coverImages = Array.from(document.querySelectorAll('[data-cover-isbn]'));
+            const isbnList = coverImages
+                .map(img => img.getAttribute('data-cover-isbn'))
+                .filter(isbn => /^\d{13}$/.test(isbn));
+            if (isbnList.length === 0) {
+                return;
+            }
+
+            for (let index = 0; index < isbnList.length; index += openBdBatchSize) {
+                const batch = isbnList.slice(index, index + openBdBatchSize);
+                try {
+                    const response = await fetch(`/api/book/covers?isbn=${batch.map(encodeURIComponent).join(',')}`);
+                    if (!response.ok) {
+                        throw new Error('cover request failed');
+                    }
+                    const coverUrls = await response.json();
+                    batch.forEach(isbn => {
+                        document.querySelectorAll(`[data-cover-isbn="${isbn}"]`).forEach(img => {
+                            applyCoverImage(img, coverUrls[isbn]);
+                        });
+                    });
+                } catch (error) {
+                    batch.forEach(isbn => {
+                        document.querySelectorAll(`[data-cover-isbn="${isbn}"]`).forEach(showCoverPlaceholder);
+                    });
+                    console.warn('openBDから書影を取得できませんでした。', error);
+                }
+            }
+        }
+
+        function updateLendingCounts() {
+            const rows = Array.from(document.querySelectorAll('[data-lending-row]'));
+            const bookCount = rows.length;
+            const dueSoonCount = rows.filter(row => row.getAttribute('data-due-alert') === 'true').length;
+            const totalCount = document.getElementById('lending-total-count');
+            const dueSoonTotal = document.getElementById('lending-due-soon-count');
+            const emptyState = document.getElementById('lending-empty-state');
+            const tableWrap = document.getElementById('lending-table-wrap');
+            const pagination = document.getElementById('lending-pagination');
+
+            if (totalCount) {
+                totalCount.textContent = bookCount;
+            }
+            if (dueSoonTotal) {
+                dueSoonTotal.textContent = dueSoonCount;
+            }
+            if (emptyState) {
+                emptyState.hidden = bookCount !== 0;
+            }
+            if (tableWrap) {
+                tableWrap.hidden = bookCount === 0;
+            }
+            if (pagination) {
+                pagination.hidden = bookCount === 0;
+            }
+        }
+
+        function returnBook(isbn) {
+            fetch('/api/book/return', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    [csrfHeader]: csrfToken
+                },
+                body: JSON.stringify({isbn})
+            }).then(response => {
+                if (!response.ok) {
+                    throw new Error('return request failed');
+                }
+                const row = document.querySelector(`[data-lending-row="${isbn}"]`);
+                row?.remove();
+                updateLendingCounts();
+            }).catch(error => {
+                console.error('Error:', error);
+                alert('書籍の返却に失敗しました');
+            });
+        }
+
+        window.addEventListener('DOMContentLoaded', () => {
+            hydrateLendingCovers();
+            document.querySelectorAll('[data-return-isbn]').forEach(button => {
+                button.addEventListener('click', () => returnBook(button.getAttribute('data-return-isbn')));
+            });
+            updateLendingCounts();
+        });
     </script>
 </head>
-<body>
-<div id="foo" th:replace="~{common/nav-bar :: bar}"></div>
-<div class="table-container">
-    <table id="book-table" class="table">
-        <thead class="table-header">
-        <tr>
-            <th scope="col" class="table-cell">書籍名</th>
-            <th scope="col" class="table-cell">出版社</th>
-            <th scope="col" class="table-cell">著者名</th>
-            <th scope="col" class="table-cell">貸出日</th>
-            <th scope="col" class="table-cell">返却</th>
-        </tr>
-        </thead>
+<body class="lending-screen">
+<div id="header" th:replace="~{common/nav-bar :: bar}"></div>
 
-        <tbody>
-        <tr th:each="book : ${books}" class="table-row">
-            <th scope="row" class="table-cell font-medium" th:text="${book.title}"></th>
-            <td class="table-cell" th:text="${book.publisher}"></td>
-            <td class="table-cell" th:text="${book.author}"></td>
-            <td class="table-cell" th:text="${#temporals.format(book.rentalAt, 'yyyy-MM-dd HH:mm:ss')}"></td>
-            <td class="table-cell" style="text-align: center; vertical-align: middle;">
-                <label style="cursor: pointer;display: inline-block;vertical-align: middle;"
-                       class="material-symbols-outlined"
-                       th:attr="data-isbn=${book.isbn}" onclick="returnBook(event)">unarchive</label>
-            </td>
-        </tr>
-        </tbody>
-    </table>
-</div>
+<main class="lending-main">
+    <section class="lending-heading">
+        <div class="lending-heading-title">
+            <span class="lending-heading-icon">
+                <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+                    <path d="M6.75 4.75h10.5A1.75 1.75 0 0 1 19 6.5v11a1.75 1.75 0 0 1-1.75 1.75H6.75A1.75 1.75 0 0 1 5 17.5v-11a1.75 1.75 0 0 1 1.75-1.75Z" stroke="currentColor" stroke-width="1.8"/>
+                    <path d="M8.75 8.25h6.5M8.75 12h6.5M8.75 15.75h3.75" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+                </svg>
+            </span>
+            <h1>借りている書籍</h1>
+        </div>
+        <p>現在借りている書籍の一覧です。返却期限や貸出状況を確認できます。</p>
+    </section>
+
+    <section class="lending-summary-card" aria-label="借りている書籍の概要">
+        <div class="lending-summary-item">
+            <span class="lending-summary-icon">
+                <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+                    <path d="M4.75 5.5C4.75 4.12 5.87 3 7.25 3H10c1.1 0 2 .9 2 2v15.25C12 19.56 11.44 19 10.75 19h-3.5A2.5 2.5 0 0 1 4.75 16.5v-11Z" stroke="currentColor" stroke-width="1.8"/>
+                    <path d="M19.25 5.5C19.25 4.12 18.13 3 16.75 3H14c-1.1 0-2 .9-2 2v15.25c0-.69.56-1.25 1.25-1.25h3.5a2.5 2.5 0 0 0 2.5-2.5v-11Z" stroke="currentColor" stroke-width="1.8"/>
+                </svg>
+            </span>
+            <div>
+                <span class="lending-summary-label">借りている冊数</span>
+                <strong><span id="lending-total-count" th:text="${bookCount}">0</span><span>冊</span></strong>
+            </div>
+        </div>
+        <div class="lending-summary-item">
+            <span class="lending-summary-icon">
+                <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+                    <path d="M7 3.75v3M17 3.75v3M4.75 9.25h14.5M6.5 5.25h11A1.75 1.75 0 0 1 19.25 7v10.5a1.75 1.75 0 0 1-1.75 1.75h-11a1.75 1.75 0 0 1-1.75-1.75V7A1.75 1.75 0 0 1 6.5 5.25Z" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+                </svg>
+            </span>
+            <div>
+                <span class="lending-summary-label">返却期限が近い書籍</span>
+                <strong><span id="lending-due-soon-count" th:text="${dueSoonCount}">0</span><span>冊</span></strong>
+            </div>
+        </div>
+    </section>
+
+    <section class="lending-card">
+        <p id="lending-empty-state" class="lending-empty-state" th:hidden="${bookCount != 0}">現在借りている書籍はありません。</p>
+        <div id="lending-table-wrap" class="lending-table-wrap" th:hidden="${bookCount == 0}">
+            <table id="book-table" class="table lending-table">
+                <thead class="table-header">
+                <tr>
+                    <th scope="col" class="table-cell">書籍</th>
+                    <th scope="col" class="table-cell">出版社</th>
+                    <th scope="col" class="table-cell">著者</th>
+                    <th scope="col" class="table-cell">貸出日</th>
+                    <th scope="col" class="table-cell">返却期限</th>
+                    <th scope="col" class="table-cell">ステータス</th>
+                    <th scope="col" class="table-cell">操作</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="book : ${displayBooks}" class="table-row lending-row"
+                    th:attr="data-lending-row=${book.isbn}, data-due-alert=${book.dueSoon || book.overdue}">
+                    <th scope="row" class="table-cell font-medium lending-book-cell">
+                        <span class="lending-cover-frame">
+                            <img class="book-cover" th:attr="data-cover-isbn=${book.isbn}, data-cover-title=${book.title}" th:alt="${book.title + ' の書影'}" loading="lazy" hidden>
+                            <span class="cover-placeholder" aria-hidden="true">
+                                <span class="cover-placeholder-text">NO IMAGE</span>
+                            </span>
+                        </span>
+                        <span class="lending-book-title-group">
+                            <span class="lending-book-title" th:text="${book.title}"></span>
+                        </span>
+                    </th>
+                    <td class="table-cell" th:text="${book.publisher}"></td>
+                    <td class="table-cell" th:text="${book.author}"></td>
+                    <td class="table-cell">
+                        <span class="lending-date">
+                            <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+                                <path d="M7 3.75v3M17 3.75v3M4.75 9.25h14.5M6.5 5.25h11A1.75 1.75 0 0 1 19.25 7v10.5a1.75 1.75 0 0 1-1.75 1.75h-11a1.75 1.75 0 0 1-1.75-1.75V7A1.75 1.75 0 0 1 6.5 5.25Z" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+                            </svg>
+                            <span th:text="${book.rentalAt != null ? #temporals.format(book.rentalAt, 'yyyy/MM/dd') : '-'}"></span>
+                        </span>
+                        <span class="lending-time" th:text="${book.rentalAt != null ? #temporals.format(book.rentalAt, 'HH:mm') : ''}"></span>
+                    </td>
+                    <td class="table-cell">
+                        <span class="lending-due">
+                            <span class="lending-date">
+                                <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+                                    <path d="M7 3.75v3M17 3.75v3M4.75 9.25h14.5M6.5 5.25h11A1.75 1.75 0 0 1 19.25 7v10.5a1.75 1.75 0 0 1-1.75 1.75h-11a1.75 1.75 0 0 1-1.75-1.75V7A1.75 1.75 0 0 1 6.5 5.25Z" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+                                </svg>
+                                <span th:text="${book.dueAt != null ? #temporals.format(book.dueAt, 'yyyy/MM/dd') : '-'}"></span>
+                            </span>
+                            <span class="lending-remaining" th:classappend="${book.overdue} ? ' is-overdue' : (${book.dueSoon} ? ' is-due-soon' : '')"
+                                  th:text="${book.dueAt == null ? '' : (book.overdue ? '(期限超過)' : '(あと' + book.remainingDays + '日)')}"></span>
+                        </span>
+                    </td>
+                    <td class="table-cell">
+                        <span class="lending-status" th:classappend="${book.overdue} ? ' is-overdue' : (${book.dueSoon} ? ' is-due-soon' : '')"
+                              th:text="${book.statusLabel}">貸出中</span>
+                    </td>
+                    <td class="table-cell">
+                        <button type="button" class="lending-return-button" th:attr="data-return-isbn=${book.isbn}, aria-label=${book.title + ' を返却する'}">
+                            <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+                                <path d="M6.75 5.75h10.5v12.5H6.75z" stroke="currentColor" stroke-width="1.8"/>
+                                <path d="M12 9v6M9.5 12H15" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+                            </svg>
+                            返却する
+                        </button>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+        <div id="lending-pagination" class="lending-pagination" th:hidden="${bookCount == 0}">
+            <button type="button" disabled aria-label="前のページ">
+                <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+                    <path d="M14.5 7.5 10 12l4.5 4.5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </button>
+            <span aria-current="page">1</span>
+            <button type="button" disabled aria-label="次のページ">
+                <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+                    <path d="M9.5 7.5 14 12l-4.5 4.5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </button>
+        </div>
+    </section>
+
+    <section class="lending-note" aria-label="返却期限について">
+        <span class="lending-note-icon">i</span>
+        <div>
+            <h2>ご確認ください</h2>
+            <p th:text="${'返却期限を過ぎると、延滞料金が発生する場合があります。返却期限は貸出日から' + returnDueDays + '日後です。'}"></p>
+        </div>
+    </section>
+</main>
 </body>
 </html>

--- a/src/main/resources/templates/user/book-lending.html
+++ b/src/main/resources/templates/user/book-lending.html
@@ -71,7 +71,7 @@
         function updateLendingCounts() {
             const rows = Array.from(document.querySelectorAll('[data-lending-row]'));
             const bookCount = rows.length;
-            const dueSoonCount = rows.filter(row => row.getAttribute('data-due-alert') === 'true').length;
+            const dueSoonCount = rows.filter(row => row.getAttribute('data-due-soon') === 'true').length;
             const totalCount = document.getElementById('lending-total-count');
             const dueSoonTotal = document.getElementById('lending-due-soon-count');
             const emptyState = document.getElementById('lending-empty-state');
@@ -185,7 +185,7 @@
                 </thead>
                 <tbody>
                 <tr th:each="book : ${displayBooks}" class="table-row lending-row"
-                    th:attr="data-lending-row=${book.isbn}, data-due-alert=${book.dueSoon || book.overdue}">
+                    th:attr="data-lending-row=${book.isbn}, data-due-soon=${book.dueSoon}">
                     <th scope="row" class="table-cell font-medium lending-book-cell">
                         <span class="lending-cover-frame">
                             <img class="book-cover" th:attr="data-cover-isbn=${book.isbn}, data-cover-title=${book.title}" th:alt="${book.title + ' の書影'}" loading="lazy" hidden>

--- a/src/test/java/jp/co/solxyz/jsn/springbootadvincedexam/app/user/book/controller/BookReturnControllerTest.java
+++ b/src/test/java/jp/co/solxyz/jsn/springbootadvincedexam/app/user/book/controller/BookReturnControllerTest.java
@@ -84,6 +84,10 @@ class BookReturnControllerTest {
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.view().name("user/book-lending"))
                 .andExpect(MockMvcResultMatchers.model().attribute("activeMenu", "lending"))
+                .andExpect(MockMvcResultMatchers.model().attribute("bookCount", 1))
+                .andExpect(MockMvcResultMatchers.model().attribute("dueSoonCount", 0L))
+                .andExpect(MockMvcResultMatchers.model().attribute("returnDueDays", 14))
+                .andExpect(MockMvcResultMatchers.model().attributeExists("displayBooks"))
                 .andExpect(MockMvcResultMatchers.model().attribute("books", expectedUnreturnedBooks));
 
         verify(bookLendingService, times(1)).getCurrentUserBooks(expectedUserId);
@@ -127,6 +131,10 @@ class BookReturnControllerTest {
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.view().name("user/book-lending"))
                 .andExpect(MockMvcResultMatchers.model().attribute("activeMenu", "lending"))
+                .andExpect(MockMvcResultMatchers.model().attribute("bookCount", 2))
+                .andExpect(MockMvcResultMatchers.model().attribute("dueSoonCount", 0L))
+                .andExpect(MockMvcResultMatchers.model().attribute("returnDueDays", 14))
+                .andExpect(MockMvcResultMatchers.model().attributeExists("displayBooks"))
                 .andExpect(MockMvcResultMatchers.model().attribute("books", expectedUnreturnedBooks));
 
         verify(bookLendingService, times(1)).getCurrentUserBooks(expectedUserId);
@@ -146,6 +154,10 @@ class BookReturnControllerTest {
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.view().name("user/book-lending"))
                 .andExpect(MockMvcResultMatchers.model().attribute("activeMenu", "lending"))
+                .andExpect(MockMvcResultMatchers.model().attribute("bookCount", 0))
+                .andExpect(MockMvcResultMatchers.model().attribute("dueSoonCount", 0L))
+                .andExpect(MockMvcResultMatchers.model().attribute("returnDueDays", 14))
+                .andExpect(MockMvcResultMatchers.model().attribute("displayBooks", Collections.emptyList()))
                 .andExpect(MockMvcResultMatchers.model().attribute("books", Collections.emptyList()));
 
         verify(bookLendingService, times(1)).getCurrentUserBooks(expectedUserId);

--- a/src/test/java/jp/co/solxyz/jsn/springbootadvincedexam/app/user/book/controller/BookReturnControllerTest.java
+++ b/src/test/java/jp/co/solxyz/jsn/springbootadvincedexam/app/user/book/controller/BookReturnControllerTest.java
@@ -17,13 +17,15 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.List;
 
-import static org.hamcrest.Matchers.containsString;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
@@ -34,17 +36,47 @@ import static org.springframework.security.test.web.servlet.setup.SecurityMockMv
 
 @SpringBootTest
 class BookReturnControllerTest {
+    /**
+     * テストで使用する固定の現在日
+     */
+    private static final LocalDate TODAY = LocalDate.of(2026, 5, 17);
 
+    /**
+     * テストで使用する固定のタイムゾーン
+     */
+    private static final ZoneId TEST_ZONE = ZoneId.of("Asia/Tokyo");
+
+    /**
+     * 書籍貸出サービス
+     */
     @MockitoBean
     private BookLendingService bookLendingService;
 
+    /**
+     * 現在日時取得用Clock
+     */
+    @MockitoBean
+    private Clock clock;
+
+    /**
+     * ログインユーザ情報
+     */
     @Mock
     private MyUserDetails userDetails;
 
+    /**
+     * Webアプリケーションコンテキスト
+     */
     private final WebApplicationContext context;
 
+    /**
+     * Spring MVCテスト用モック
+     */
     private MockMvc mockMvc;
 
+    /**
+     * テスト用ユーザID
+     */
     private final String USER_ID = "user1";
 
     BookReturnControllerTest(WebApplicationContext context) {
@@ -61,13 +93,15 @@ class BookReturnControllerTest {
                 .build();
 
         when(userDetails.getUserId()).thenReturn(USER_ID);
+        when(clock.instant()).thenReturn(TODAY.atStartOfDay(TEST_ZONE).toInstant());
+        when(clock.getZone()).thenReturn(TEST_ZONE);
     }
 
     @Test
     @DisplayName("1件の借りている書籍がある時にindexが呼び出された場合、1件の書籍を含んだリストを返す")
     void shouldReturnBookListWhenIndexIsCalled() throws Exception {
         String expectedUserId = "user1";
-        LocalDateTime rentalAt = LocalDate.now().atTime(10, 30);
+        LocalDateTime rentalAt = TODAY.atTime(10, 30);
 
         UnreturnedBookModel unreturnedBook = new UnreturnedBookModel();
         unreturnedBook.setIsbn("isbn1");
@@ -119,7 +153,7 @@ class BookReturnControllerTest {
     @DisplayName("返却期限が近い書籍がある場合、返却期限が近い書籍数に含める")
     void shouldCountDueSoonBooks() throws Exception {
         String userId = "user1";
-        LocalDateTime rentalAt = LocalDate.now().minusDays(12).atTime(10, 30);
+        LocalDateTime rentalAt = TODAY.minusDays(12).atTime(10, 30);
 
         UnreturnedBookModel unreturnedBook = new UnreturnedBookModel();
         unreturnedBook.setIsbn("isbn1");
@@ -156,7 +190,7 @@ class BookReturnControllerTest {
     @DisplayName("返却期限を過ぎた書籍がある場合、返却期限が近い書籍数には含めない")
     void shouldExcludeOverdueBooksFromDueSoonCount() throws Exception {
         String userId = "user1";
-        LocalDateTime rentalAt = LocalDate.now().minusDays(15).atTime(10, 30);
+        LocalDateTime rentalAt = TODAY.minusDays(15).atTime(10, 30);
 
         UnreturnedBookModel unreturnedBook = new UnreturnedBookModel();
         unreturnedBook.setIsbn("isbn1");

--- a/src/test/java/jp/co/solxyz/jsn/springbootadvincedexam/app/user/book/controller/BookReturnControllerTest.java
+++ b/src/test/java/jp/co/solxyz/jsn/springbootadvincedexam/app/user/book/controller/BookReturnControllerTest.java
@@ -11,14 +11,19 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
@@ -62,12 +67,14 @@ class BookReturnControllerTest {
     @DisplayName("1件の借りている書籍がある時にindexが呼び出された場合、1件の書籍を含んだリストを返す")
     void shouldReturnBookListWhenIndexIsCalled() throws Exception {
         String expectedUserId = "user1";
+        LocalDateTime rentalAt = LocalDate.now().atTime(10, 30);
 
         UnreturnedBookModel unreturnedBook = new UnreturnedBookModel();
         unreturnedBook.setIsbn("isbn1");
         unreturnedBook.setTitle("title1");
         unreturnedBook.setAuthor("author1");
         unreturnedBook.setPublisher("publisher1");
+        unreturnedBook.setRentalAt(rentalAt);
         List<UnreturnedBookModel> unreturnedBooks = List.of(unreturnedBook);
 
         UnreturnedBookModel expectedUnreturnedBook = new UnreturnedBookModel();
@@ -75,11 +82,12 @@ class BookReturnControllerTest {
         expectedUnreturnedBook.setTitle("title1");
         expectedUnreturnedBook.setAuthor("author1");
         expectedUnreturnedBook.setPublisher("publisher1");
+        expectedUnreturnedBook.setRentalAt(rentalAt);
         List<UnreturnedBookModel> expectedUnreturnedBooks = List.of(expectedUnreturnedBook);
 
         when(bookLendingService.getCurrentUserBooks(any())).thenReturn(unreturnedBooks);
 
-        mockMvc.perform(MockMvcRequestBuilders.get("/book/return")
+        MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/book/return")
                         .with(user(userDetails)))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.view().name("user/book-lending"))
@@ -88,9 +96,97 @@ class BookReturnControllerTest {
                 .andExpect(MockMvcResultMatchers.model().attribute("dueSoonCount", 0L))
                 .andExpect(MockMvcResultMatchers.model().attribute("returnDueDays", 14))
                 .andExpect(MockMvcResultMatchers.model().attributeExists("displayBooks"))
-                .andExpect(MockMvcResultMatchers.model().attribute("books", expectedUnreturnedBooks));
+                .andExpect(MockMvcResultMatchers.content().string(containsString("data-due-soon=\"false\"")))
+                .andExpect(MockMvcResultMatchers.model().attribute("books", expectedUnreturnedBooks))
+                .andReturn();
+
+        @SuppressWarnings("unchecked")
+        List<UnreturnedBookModel> displayBooks = (List<UnreturnedBookModel>) result.getModelAndView()
+                .getModel()
+                .get("displayBooks");
+        assertThat(displayBooks).hasSize(1);
+        UnreturnedBookModel displayBook = displayBooks.get(0);
+        assertThat(displayBook.getDueAt()).isEqualTo(rentalAt.plusDays(14));
+        assertThat(displayBook.getRemainingDays()).isEqualTo(14);
+        assertThat(displayBook.isDueSoon()).isFalse();
+        assertThat(displayBook.isOverdue()).isFalse();
+        assertThat(displayBook.getStatusLabel()).isEqualTo("貸出中");
 
         verify(bookLendingService, times(1)).getCurrentUserBooks(expectedUserId);
+    }
+
+    @Test
+    @DisplayName("返却期限が近い書籍がある場合、返却期限が近い書籍数に含める")
+    void shouldCountDueSoonBooks() throws Exception {
+        String userId = "user1";
+        LocalDateTime rentalAt = LocalDate.now().minusDays(12).atTime(10, 30);
+
+        UnreturnedBookModel unreturnedBook = new UnreturnedBookModel();
+        unreturnedBook.setIsbn("isbn1");
+        unreturnedBook.setTitle("title1");
+        unreturnedBook.setAuthor("author1");
+        unreturnedBook.setPublisher("publisher1");
+        unreturnedBook.setRentalAt(rentalAt);
+
+        when(userDetails.getUserId()).thenReturn(userId);
+        when(bookLendingService.getCurrentUserBooks(userId)).thenReturn(List.of(unreturnedBook));
+
+        MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/book/return")
+                        .with(user(userDetails)))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.model().attribute("bookCount", 1))
+                .andExpect(MockMvcResultMatchers.model().attribute("dueSoonCount", 1L))
+                .andExpect(MockMvcResultMatchers.content().string(containsString("data-due-soon=\"true\"")))
+                .andReturn();
+
+        @SuppressWarnings("unchecked")
+        List<UnreturnedBookModel> displayBooks = (List<UnreturnedBookModel>) result.getModelAndView()
+                .getModel()
+                .get("displayBooks");
+        assertThat(displayBooks).hasSize(1);
+        UnreturnedBookModel displayBook = displayBooks.get(0);
+        assertThat(displayBook.getDueAt()).isEqualTo(rentalAt.plusDays(14));
+        assertThat(displayBook.getRemainingDays()).isEqualTo(2);
+        assertThat(displayBook.isDueSoon()).isTrue();
+        assertThat(displayBook.isOverdue()).isFalse();
+        assertThat(displayBook.getStatusLabel()).isEqualTo("返却間近");
+    }
+
+    @Test
+    @DisplayName("返却期限を過ぎた書籍がある場合、返却期限が近い書籍数には含めない")
+    void shouldExcludeOverdueBooksFromDueSoonCount() throws Exception {
+        String userId = "user1";
+        LocalDateTime rentalAt = LocalDate.now().minusDays(15).atTime(10, 30);
+
+        UnreturnedBookModel unreturnedBook = new UnreturnedBookModel();
+        unreturnedBook.setIsbn("isbn1");
+        unreturnedBook.setTitle("title1");
+        unreturnedBook.setAuthor("author1");
+        unreturnedBook.setPublisher("publisher1");
+        unreturnedBook.setRentalAt(rentalAt);
+
+        when(userDetails.getUserId()).thenReturn(userId);
+        when(bookLendingService.getCurrentUserBooks(userId)).thenReturn(List.of(unreturnedBook));
+
+        MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/book/return")
+                        .with(user(userDetails)))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.model().attribute("bookCount", 1))
+                .andExpect(MockMvcResultMatchers.model().attribute("dueSoonCount", 0L))
+                .andExpect(MockMvcResultMatchers.content().string(containsString("data-due-soon=\"false\"")))
+                .andReturn();
+
+        @SuppressWarnings("unchecked")
+        List<UnreturnedBookModel> displayBooks = (List<UnreturnedBookModel>) result.getModelAndView()
+                .getModel()
+                .get("displayBooks");
+        assertThat(displayBooks).hasSize(1);
+        UnreturnedBookModel displayBook = displayBooks.get(0);
+        assertThat(displayBook.getDueAt()).isEqualTo(rentalAt.plusDays(14));
+        assertThat(displayBook.getRemainingDays()).isZero();
+        assertThat(displayBook.isDueSoon()).isFalse();
+        assertThat(displayBook.isOverdue()).isTrue();
+        assertThat(displayBook.getStatusLabel()).isEqualTo("期限超過");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- 借りている書籍画面をスクリーンショットに合わせたカード型レイアウトへ刷新
- openBD書影、NO IMAGE、返却期限、残日数、貸出ステータス、返却ボタンを表示
- 貸出中書籍の表示用属性をControllerで付与し、Controllerテストを更新

## Validation
- ./gradlew test
- git diff --check
- ローカル起動後にログインし、空表示と1冊入り表示のHTML描画を確認