### PR TITLE
[codex] Update user management UI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'org.jsoup:jsoup:1.22.2'
 }
 
 tasks.named('test') {

--- a/src/main/resources/static/css/user-management.css
+++ b/src/main/resources/static/css/user-management.css
@@ -1,0 +1,645 @@
+.user-management-screen {
+    background:
+        linear-gradient(135deg, #f8fbff 0%, #eef5ff 48%, #f8fbff 100%);
+}
+
+.user-management-screen button {
+    max-width: none;
+    opacity: 1;
+}
+
+.user-management-main {
+    width: min(1230px, calc(100vw - 376px));
+    margin: 74px 48px 40px 328px;
+}
+
+.user-management-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 32px;
+    margin-bottom: 26px;
+}
+
+.page-title-group {
+    min-width: 0;
+}
+
+.page-title-row {
+    display: flex;
+    align-items: center;
+    gap: 18px;
+    margin-bottom: 8px;
+}
+
+.page-title-icon {
+    width: 44px;
+    height: 44px;
+    flex: 0 0 auto;
+    color: #2f64e5;
+}
+
+.page-title-row h1 {
+    margin: 0;
+    color: #142033;
+    font-size: 32px;
+    line-height: 1.25;
+    font-weight: 800;
+    letter-spacing: 0;
+}
+
+.page-title-group p {
+    margin: 0;
+    color: #536176;
+    font-size: 16px;
+    font-weight: 700;
+}
+
+.header-actions {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 52px;
+}
+
+.current-user {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    color: #142033;
+    font-weight: 800;
+    white-space: nowrap;
+}
+
+.current-user-avatar {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    color: #ffffff;
+    background: #2f64e5;
+    border-radius: 999px;
+    box-shadow: 0 8px 18px rgba(47, 100, 229, 0.24);
+}
+
+.current-user svg {
+    width: 18px;
+    height: 18px;
+    color: #536176;
+}
+
+.primary-action-button,
+.secondary-action-button,
+.outline-action-button,
+.copy-id-button,
+.pagination-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 9px;
+    margin: 0;
+    border-radius: 8px;
+    font-weight: 800;
+    line-height: 1;
+    transition:
+        background-color 160ms ease,
+        border-color 160ms ease,
+        color 160ms ease,
+        box-shadow 160ms ease,
+        transform 160ms ease;
+}
+
+.primary-action-button {
+    min-height: 48px;
+    padding: 0 24px;
+    color: #ffffff;
+    background: #2f64e5;
+    border: 1px solid #2f64e5;
+    box-shadow: 0 10px 24px rgba(47, 100, 229, 0.22);
+}
+
+.primary-action-button:hover {
+    background: #1f55d6;
+    border-color: #1f55d6;
+    transform: translateY(-1px);
+}
+
+.primary-action-button svg {
+    width: 20px;
+    height: 20px;
+}
+
+.secondary-action-button {
+    min-height: 44px;
+    padding: 0 20px;
+    color: #536176;
+    background: #ffffff;
+    border: 1px solid #d8e1ee;
+}
+
+.secondary-action-button:hover {
+    color: #2f64e5;
+    border-color: #b9ccf5;
+    background: #f8fbff;
+}
+
+.user-filter-panel {
+    display: grid;
+    grid-template-columns: minmax(360px, 1fr) 180px;
+    align-items: center;
+    gap: 24px;
+    margin-bottom: 30px;
+    padding: 24px 18px;
+    background: rgba(255, 255, 255, 0.96);
+    border: 1px solid #edf2f8;
+    border-radius: 8px;
+    box-shadow: 0 14px 34px rgba(25, 46, 86, 0.1);
+}
+
+.search-control,
+.permission-control {
+    position: relative;
+}
+
+.search-control {
+    width: min(540px, 100%);
+}
+
+.search-control svg {
+    position: absolute;
+    top: 50%;
+    left: 18px;
+    width: 22px;
+    height: 22px;
+    color: #7b8798;
+    transform: translateY(-50%);
+    pointer-events: none;
+}
+
+.search-control input,
+.permission-control select,
+.user-modal-body input[type="text"],
+.user-modal-body input[type="email"],
+.user-modal-body input[type="password"] {
+    width: 100%;
+    min-height: 48px;
+    margin: 0;
+    color: #142033;
+    background: #ffffff;
+    border: 1px solid #d8e1ee;
+    border-radius: 6px;
+    font-size: 15px;
+    font-weight: 700;
+}
+
+.search-control input {
+    padding: 0 18px 0 54px;
+}
+
+.permission-control {
+    justify-self: start;
+    width: 180px;
+}
+
+.permission-control select {
+    appearance: none;
+    padding: 0 42px 0 18px;
+    background-image:
+        linear-gradient(45deg, transparent 50%, #74839a 50%),
+        linear-gradient(135deg, #74839a 50%, transparent 50%);
+    background-position:
+        calc(100% - 22px) 20px,
+        calc(100% - 16px) 20px;
+    background-size: 7px 7px, 7px 7px;
+    background-repeat: no-repeat;
+    cursor: pointer;
+}
+
+.search-control input::placeholder {
+    color: #9aa6b6;
+}
+
+.search-control input:focus,
+.permission-control select:focus,
+.user-modal-body input:focus {
+    outline: 3px solid rgba(47, 100, 229, 0.18);
+    border-color: #2f64e5;
+    background: #ffffff;
+}
+
+.user-table-card {
+    overflow: hidden;
+    background: rgba(255, 255, 255, 0.97);
+    border: 1px solid #edf2f8;
+    border-radius: 8px;
+    box-shadow: 0 16px 36px rgba(25, 46, 86, 0.12);
+}
+
+.user-table-scroll {
+    overflow-x: auto;
+    padding: 18px 18px 0;
+}
+
+.user-table {
+    width: 100%;
+    min-width: 1060px;
+    border-collapse: collapse;
+    color: #253149;
+    font-size: 15px;
+    text-align: left;
+}
+
+.user-table thead {
+    color: #253149;
+    background: #f8fafc;
+}
+
+.user-table th,
+.user-table td {
+    padding: 20px 16px;
+    border-bottom: 1px solid #e5ebf3;
+    vertical-align: middle;
+}
+
+.user-table thead th {
+    padding-top: 16px;
+    padding-bottom: 16px;
+    font-size: 14px;
+    font-weight: 800;
+    white-space: nowrap;
+}
+
+.user-table tbody th,
+.user-table tbody td {
+    font-weight: 700;
+}
+
+.user-table tbody tr:hover {
+    background: #f8fbff;
+}
+
+.user-id-cell {
+    width: 310px;
+}
+
+.user-id {
+    display: inline-block;
+    width: 230px;
+    color: #253149;
+    overflow-wrap: anywhere;
+    line-height: 1.35;
+}
+
+.copy-id-button {
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    color: #64748b;
+    background: transparent;
+    border: 0;
+    vertical-align: middle;
+}
+
+.copy-id-button:hover {
+    color: #2f64e5;
+    background: #eef4ff;
+}
+
+.copy-id-button svg {
+    width: 20px;
+    height: 20px;
+}
+
+.user-name-cell {
+    min-width: 132px;
+    color: #142033;
+}
+
+.role-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 74px;
+    min-height: 30px;
+    padding: 0 12px;
+    border-radius: 7px;
+    font-size: 14px;
+    font-weight: 800;
+    white-space: nowrap;
+}
+
+.role-badge.is-admin {
+    color: #1f55d6;
+    background: #e8f0ff;
+}
+
+.role-badge.is-general {
+    color: #16814e;
+    background: #e2f7e8;
+}
+
+.admin-state-cell {
+    width: 104px;
+    text-align: center;
+}
+
+.admin-check {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 30px;
+    height: 30px;
+    color: #238443;
+    background: #d7f1da;
+    border-radius: 999px;
+}
+
+.admin-check svg {
+    width: 20px;
+    height: 20px;
+}
+
+.admin-empty {
+    display: inline-block;
+    width: 18px;
+    height: 18px;
+    border: 2px solid #a6b3c4;
+    border-radius: 6px;
+}
+
+.row-actions {
+    display: flex;
+    align-items: center;
+    gap: 18px;
+}
+
+.outline-action-button {
+    min-height: 40px;
+    padding: 0 14px;
+    background: #ffffff;
+    border: 1.5px solid currentColor;
+    font-size: 14px;
+}
+
+.outline-action-button svg {
+    width: 18px;
+    height: 18px;
+}
+
+.edit-action {
+    color: #2f64e5;
+}
+
+.edit-action:hover {
+    color: #ffffff;
+    background: #2f64e5;
+    border-color: #2f64e5;
+}
+
+.delete-action {
+    color: #ef3535;
+}
+
+.delete-action:hover {
+    color: #ffffff;
+    background: #ef3535;
+    border-color: #ef3535;
+}
+
+.no-results-row td {
+    padding: 32px 16px;
+    color: #64748b;
+    text-align: center;
+}
+
+.pagination-bar {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    min-height: 84px;
+}
+
+.pagination-button {
+    width: 44px;
+    height: 44px;
+    padding: 0;
+    color: #2f64e5;
+    background: #ffffff;
+    border: 1px solid #c4d4f8;
+    font-size: 18px;
+}
+
+.pagination-button svg {
+    width: 20px;
+    height: 20px;
+}
+
+.pagination-button.is-current {
+    color: #2f64e5;
+    border-color: #2f64e5;
+    box-shadow: 0 8px 18px rgba(47, 100, 229, 0.12);
+}
+
+.pagination-button:disabled {
+    color: #a7b2c3;
+    background: #f8fafc;
+    border-color: #e2e8f0;
+    cursor: not-allowed;
+}
+
+.permission-note {
+    display: flex;
+    gap: 18px;
+    margin-top: 28px;
+    padding: 18px 20px;
+    color: #253149;
+    background: rgba(247, 251, 255, 0.84);
+    border: 1px solid #b9d0fb;
+    border-radius: 8px;
+}
+
+.permission-note-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    flex: 0 0 auto;
+    color: #ffffff;
+    background: #2f64e5;
+    border-radius: 999px;
+    font-size: 18px;
+    font-weight: 800;
+    font-style: normal;
+}
+
+.permission-note h2 {
+    margin: 2px 0 8px;
+    color: #2f64e5;
+    font-size: 16px;
+    font-weight: 800;
+}
+
+.permission-note p {
+    margin: 0 0 6px;
+    color: #536176;
+    font-size: 14px;
+    font-weight: 700;
+    line-height: 1.5;
+}
+
+.permission-note p:last-child {
+    margin-bottom: 0;
+}
+
+.user-modal {
+    padding: 24px;
+    background: rgba(15, 23, 42, 0.34);
+}
+
+.is-modal-open {
+    overflow: hidden;
+}
+
+.user-modal-dialog {
+    width: min(520px, calc(100vw - 48px));
+}
+
+.user-modal-content {
+    width: 100%;
+    max-width: none;
+    padding: 0;
+    border-radius: 8px;
+    box-shadow: 0 24px 70px rgba(15, 23, 42, 0.26);
+    overflow: hidden;
+}
+
+.user-modal-header {
+    padding: 22px 24px;
+}
+
+.user-modal-header .modal-title {
+    margin: 0;
+    color: #142033;
+    font-size: 22px;
+    font-weight: 800;
+}
+
+.user-modal-close {
+    width: 38px;
+    height: 38px;
+    padding: 0;
+    color: #64748b;
+}
+
+.user-modal-close svg {
+    width: 22px;
+    height: 22px;
+}
+
+.user-modal-body {
+    display: grid;
+    gap: 18px;
+    padding: 24px;
+}
+
+.user-modal-body label {
+    display: grid;
+    gap: 8px;
+    color: #253149;
+    font-size: 14px;
+    font-weight: 800;
+}
+
+.user-modal-body input[type="text"],
+.user-modal-body input[type="email"],
+.user-modal-body input[type="password"] {
+    padding: 0 14px;
+}
+
+.admin-toggle {
+    display: flex;
+    grid-template-columns: none;
+    flex-direction: row;
+    align-items: center;
+    gap: 10px;
+    min-height: 42px;
+}
+
+.admin-toggle input {
+    width: 18px;
+    height: 18px;
+    margin: 0;
+    accent-color: #2f64e5;
+}
+
+.user-modal-footer {
+    justify-content: flex-end;
+    gap: 12px;
+    padding: 18px 24px 24px;
+}
+
+@media (max-width: 960px) {
+    .user-management-main {
+        width: auto;
+        margin: 28px 16px 34px;
+    }
+
+    .user-management-header {
+        flex-direction: column;
+    }
+
+    .header-actions {
+        width: 100%;
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+        gap: 18px;
+    }
+
+    .user-filter-panel {
+        grid-template-columns: 1fr;
+    }
+
+    .search-control,
+    .permission-control {
+        width: 100%;
+    }
+}
+
+@media (max-width: 640px) {
+    .page-title-row h1 {
+        font-size: 28px;
+    }
+
+    .header-actions {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .current-user {
+        justify-content: flex-end;
+    }
+
+    .primary-action-button {
+        width: 100%;
+    }
+
+    .user-filter-panel {
+        padding: 18px;
+    }
+
+    .permission-note {
+        flex-direction: column;
+    }
+
+    .user-modal-footer {
+        flex-direction: column-reverse;
+    }
+
+    .user-modal-footer button {
+        width: 100%;
+    }
+}

--- a/src/main/resources/templates/admin/user-management.html
+++ b/src/main/resources/templates/admin/user-management.html
@@ -247,10 +247,11 @@ document.addEventListener("DOMContentLoaded", () => {
             <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
                 <path d="m20 20-4.35-4.35M18 11a7 7 0 1 1-14 0 7 7 0 0 1 14 0Z" stroke="currentColor" stroke-width="1.9" stroke-linecap="round"/>
             </svg>
-            <input id="userSearch" type="search" placeholder="ユーザ名、メールアドレス、ユーザIDで検索" autocomplete="off">
+            <input id="userSearch" type="search" placeholder="ユーザ名、メールアドレス、ユーザIDで検索" autocomplete="off"
+                   aria-label="ユーザ検索">
         </label>
         <label class="permission-control" for="permissionFilter">
-            <select id="permissionFilter">
+            <select id="permissionFilter" aria-label="権限フィルター">
                 <option value="all">すべての権限</option>
                 <option value="admin">管理者</option>
                 <option value="general">一般ユーザ</option>

--- a/src/main/resources/templates/admin/user-management.html
+++ b/src/main/resources/templates/admin/user-management.html
@@ -21,7 +21,9 @@ const headers = {
   "Content-Type": "application/json",
   [csrfHeader]: csrfToken,
 };
+const USER_MODAL_FOCUSABLE_SELECTOR = "button, [href], input, select, textarea, [tabindex]:not([tabindex=\"-1\"])";
 let userModalMode = "create";
+let userModalTrigger = null;
 
 function addUser() {
   const API_ENDPOINT = ROOT_API_URL;
@@ -92,7 +94,7 @@ function deleteUser(event) {
     });
 }
 
-function openCreateUserModal() {
+function openCreateUserModal(event) {
   userModalMode = "create";
   document.getElementById("user-modal-title").textContent = "ユーザを追加";
   document.getElementById("modalSubmitButton").textContent = "追加";
@@ -102,7 +104,7 @@ function openCreateUserModal() {
   document.getElementById("modalPassword").value = "";
   document.getElementById("modalPassword").placeholder = "初期パスワード";
   document.getElementById("modalIsAdmin").checked = false;
-  openUserModal();
+  openUserModal(event.currentTarget);
 }
 
 function openEditUserModal(event) {
@@ -116,11 +118,12 @@ function openEditUserModal(event) {
   document.getElementById("modalPassword").value = "";
   document.getElementById("modalPassword").placeholder = "変更する場合のみ入力";
   document.getElementById("modalIsAdmin").checked = row.dataset.role === "admin";
-  openUserModal();
+  openUserModal(event.currentTarget);
 }
 
-function openUserModal() {
+function openUserModal(trigger) {
   const modal = document.getElementById("user-modal");
+  userModalTrigger = trigger || document.activeElement;
   modal.classList.add("is-open");
   modal.setAttribute("aria-hidden", "false");
   document.body.classList.add("is-modal-open");
@@ -129,9 +132,59 @@ function openUserModal() {
 
 function closeUserModal() {
   const modal = document.getElementById("user-modal");
+  const shouldRestoreFocus = modal.classList.contains("is-open");
   modal.classList.remove("is-open");
   modal.setAttribute("aria-hidden", "true");
   document.body.classList.remove("is-modal-open");
+
+  if (shouldRestoreFocus && userModalTrigger && document.contains(userModalTrigger)) {
+    userModalTrigger.focus({preventScroll: true});
+  }
+  userModalTrigger = null;
+}
+
+function getFocusableUserModalElements() {
+  const modal = document.getElementById("user-modal");
+  return Array.from(modal.querySelectorAll(USER_MODAL_FOCUSABLE_SELECTOR))
+    .filter((element) => !element.disabled && element.getClientRects().length > 0);
+}
+
+function trapUserModalFocus(event) {
+  const modal = document.getElementById("user-modal");
+  if (!modal.classList.contains("is-open")) {
+    return;
+  }
+
+  if (event.key === "Escape") {
+    event.preventDefault();
+    closeUserModal();
+    return;
+  }
+
+  if (event.key !== "Tab") {
+    return;
+  }
+
+  const focusableElements = getFocusableUserModalElements();
+  if (focusableElements.length === 0) {
+    event.preventDefault();
+    modal.focus({preventScroll: true});
+    return;
+  }
+
+  const firstElement = focusableElements[0];
+  const lastElement = focusableElements[focusableElements.length - 1];
+
+  if (!modal.contains(document.activeElement)) {
+    event.preventDefault();
+    firstElement.focus({preventScroll: true});
+  } else if (event.shiftKey && document.activeElement === firstElement) {
+    event.preventDefault();
+    lastElement.focus({preventScroll: true});
+  } else if (!event.shiftKey && document.activeElement === lastElement) {
+    event.preventDefault();
+    firstElement.focus({preventScroll: true});
+  }
 }
 
 function submitUserForm() {
@@ -184,10 +237,20 @@ function copyUserIdWithFallback(userId) {
   textarea.setAttribute("readonly", "");
   textarea.style.position = "fixed";
   textarea.style.opacity = "0";
-  document.body.appendChild(textarea);
-  textarea.select();
-  document.execCommand("copy");
-  document.body.removeChild(textarea);
+
+  try {
+    document.body.appendChild(textarea);
+    textarea.select();
+    if (!document.execCommand("copy")) {
+      alert("ユーザIDをコピーできませんでした。手動でコピーしてください: " + userId);
+    }
+  } catch (error) {
+    alert("ユーザIDをコピーできませんでした。手動でコピーしてください: " + userId);
+  } finally {
+    if (textarea.parentNode) {
+      document.body.removeChild(textarea);
+    }
+  }
 }
 
 document.addEventListener("DOMContentLoaded", () => {
@@ -199,11 +262,7 @@ document.addEventListener("DOMContentLoaded", () => {
       closeUserModal();
     }
   });
-  document.addEventListener("keydown", (event) => {
-    if (event.key === "Escape") {
-      closeUserModal();
-    }
-  });
+  document.addEventListener("keydown", trapUserModalFocus);
 });
 
     </script>
@@ -233,7 +292,7 @@ document.addEventListener("DOMContentLoaded", () => {
                     <path d="m7 10 5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                 </svg>
             </div>
-            <button type="button" class="primary-action-button" onclick="openCreateUserModal()">
+            <button type="button" class="primary-action-button" onclick="openCreateUserModal(event)">
                 <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
                     <path d="M12 5v14M5 12h14" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
                 </svg>

--- a/src/main/resources/templates/admin/user-management.html
+++ b/src/main/resources/templates/admin/user-management.html
@@ -5,8 +5,9 @@
     <meta charset="UTF-8">
     <title>ユーザ管理</title>
     <link th:href="@{/css/main.css}" rel="stylesheet">
-    <link th:href="@{/css/list.css}" rel="stylesheet">
     <link th:href="@{/css/button.css}" rel="stylesheet">
+    <link th:href="@{/css/modal.css}" rel="stylesheet">
+    <link th:href="@{/css/user-management.css}" rel="stylesheet">
 
     <meta name="_csrf" th:content="${_csrf.token}"/>
     <meta name="_csrf_header" th:content="${_csrf.headerName}"/>
@@ -20,13 +21,14 @@ const headers = {
   "Content-Type": "application/json",
   [csrfHeader]: csrfToken,
 };
+let userModalMode = "create";
 
 function addUser() {
   const API_ENDPOINT = ROOT_API_URL;
-  const userName = document.getElementById("userName").value;
-  const email = document.getElementById("email").value;
-  const isAdmin = document.getElementById("isAdmin").checked;
-  const password = document.getElementById("password").value;
+  const userName = document.getElementById("modalUserName").value;
+  const email = document.getElementById("modalEmail").value;
+  const isAdmin = document.getElementById("modalIsAdmin").checked;
+  const password = document.getElementById("modalPassword").value;
   const managedUser = {
     userName: userName,
     email: email,
@@ -44,14 +46,13 @@ function addUser() {
     });
 }
 
-function updateUser(event) {
+function updateUser() {
   const API_ENDPOINT = ROOT_API_URL;
-  const row = event.target.closest(".table-row");
-  const userId = row.querySelector(".userId").textContent;
-  const userName = row.querySelector(".userName").value;
-  const email = row.querySelector(".email").value;
-  const password = row.querySelector(".password").value;
-  const isAdmin = row.querySelector(".isAdmin").checked;
+  const userId = document.getElementById("modalUserId").value;
+  const userName = document.getElementById("modalUserName").value;
+  const email = document.getElementById("modalEmail").value;
+  const password = document.getElementById("modalPassword").value;
+  const isAdmin = document.getElementById("modalIsAdmin").checked;
 
   const managedUser = {
     userId: userId,
@@ -73,11 +74,13 @@ function updateUser(event) {
 
 function deleteUser(event) {
   const API_ENDPOINT = ROOT_API_URL + "/";
-  const row = event.target.closest(".table-row");
-  const userId = row.querySelector(".userId").textContent;
-  const managedUser = {
-    userId: userId,
-  };
+  const row = event.target.closest(".user-row");
+  const userId = row.dataset.userId;
+  const userName = row.dataset.userName;
+
+  if (!confirm(userName + " を削除します。よろしいですか？")) {
+    return;
+  }
 
   fetcher.delete(API_ENDPOINT + userId, headers)
     .then(() => {
@@ -89,58 +92,297 @@ function deleteUser(event) {
     });
 }
 
+function openCreateUserModal() {
+  userModalMode = "create";
+  document.getElementById("user-modal-title").textContent = "ユーザを追加";
+  document.getElementById("modalSubmitButton").textContent = "追加";
+  document.getElementById("modalUserId").value = "";
+  document.getElementById("modalUserName").value = "";
+  document.getElementById("modalEmail").value = "";
+  document.getElementById("modalPassword").value = "";
+  document.getElementById("modalPassword").placeholder = "初期パスワード";
+  document.getElementById("modalIsAdmin").checked = false;
+  openUserModal();
+}
+
+function openEditUserModal(event) {
+  const row = event.target.closest(".user-row");
+  userModalMode = "edit";
+  document.getElementById("user-modal-title").textContent = "ユーザを編集";
+  document.getElementById("modalSubmitButton").textContent = "更新";
+  document.getElementById("modalUserId").value = row.dataset.userId;
+  document.getElementById("modalUserName").value = row.dataset.userName;
+  document.getElementById("modalEmail").value = row.dataset.email;
+  document.getElementById("modalPassword").value = "";
+  document.getElementById("modalPassword").placeholder = "変更する場合のみ入力";
+  document.getElementById("modalIsAdmin").checked = row.dataset.role === "admin";
+  openUserModal();
+}
+
+function openUserModal() {
+  const modal = document.getElementById("user-modal");
+  modal.classList.add("is-open");
+  modal.setAttribute("aria-hidden", "false");
+  document.body.classList.add("is-modal-open");
+  document.getElementById("modalUserName").focus({preventScroll: true});
+}
+
+function closeUserModal() {
+  const modal = document.getElementById("user-modal");
+  modal.classList.remove("is-open");
+  modal.setAttribute("aria-hidden", "true");
+  document.body.classList.remove("is-modal-open");
+}
+
+function submitUserForm() {
+  if (userModalMode === "edit") {
+    updateUser();
+    return;
+  }
+  addUser();
+}
+
+function filterUsers() {
+  const query = document.getElementById("userSearch").value.trim().toLowerCase();
+  const role = document.getElementById("permissionFilter").value;
+  const rows = document.querySelectorAll(".user-row");
+  let visibleCount = 0;
+
+  rows.forEach((row) => {
+    const keyword = [
+      row.dataset.userId,
+      row.dataset.userName,
+      row.dataset.email,
+    ].join(" ").toLowerCase();
+    const matchesKeyword = keyword.includes(query);
+    const matchesRole = role === "all" || row.dataset.role === role;
+    const isVisible = matchesKeyword && matchesRole;
+    row.hidden = !isVisible;
+    if (isVisible) {
+      visibleCount++;
+    }
+  });
+
+  const noResultsRow = document.getElementById("noResultsRow");
+  noResultsRow.hidden = visibleCount !== 0;
+}
+
+function copyUserId(event) {
+  const userId = event.target.closest(".user-row").dataset.userId;
+
+  if (navigator.clipboard && window.isSecureContext) {
+    navigator.clipboard.writeText(userId).catch(() => copyUserIdWithFallback(userId));
+    return;
+  }
+
+  copyUserIdWithFallback(userId);
+}
+
+function copyUserIdWithFallback(userId) {
+  const textarea = document.createElement("textarea");
+  textarea.value = userId;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+  textarea.select();
+  document.execCommand("copy");
+  document.body.removeChild(textarea);
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  document.getElementById("userSearch").addEventListener("input", filterUsers);
+  document.getElementById("permissionFilter").addEventListener("change", filterUsers);
+  filterUsers();
+  document.getElementById("user-modal").addEventListener("click", (event) => {
+    if (event.target.id === "user-modal") {
+      closeUserModal();
+    }
+  });
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape") {
+      closeUserModal();
+    }
+  });
+});
+
     </script>
 </head>
-<body>
+<body class="user-management-screen">
 <div id="foo" th:replace="~{common/nav-bar :: bar}"></div>
-<h2 class="section-title">ユーザ追加</h2>
-<div class="table-container">
-    <table id="book-table" class="table">
-        <thead class="table-header">
-        <tr>
-            <th scope="col" class="table-cell">ユーザID</th>
-            <th scope="col" class="table-cell">ユーザ名</th>
-            <th scope="col" class="table-cell">メール</th>
-            <th scope="col" class="table-cell">新規パスワード</th>
-            <th scope="col" class="table-cell">管理者</th>
-            <th scope="col" class="table-cell">操作</th>
-        </tr>
-        </thead>
-        <tbody>
-        <tr class="table-row">
-            <td class="table-cell">
-                <laba>******</laba>
-            </td>
-            <td class="table-cell">
-                <input id="userName" type="text" placeholder="田中　太郎">
-            </td>
-            <td class="table-cell">
-                <input id="email" type="text" placeholder="メールアドレス">
-            </td>
-            <td class="table-cell">
-                <input id="password" type="password" placeholder="********" maxlength="10">
-            </td>
-            <td class="table-cell">
-                <input id="isAdmin" type="checkbox">
-            </td>
-            <td class="table-cell">
-                <button class="add-button" onclick="addUser()">追加</button>
-            </td>
-        </tr>
+<main class="user-management-main">
+    <header class="user-management-header">
+        <div class="page-title-group">
+            <div class="page-title-row">
+                <svg class="page-title-icon" aria-hidden="true" viewBox="0 0 24 24" fill="none">
+                    <path d="M9.5 12.25a4 4 0 1 0 0-8 4 4 0 0 0 0 8Z" stroke="currentColor" stroke-width="1.9"/>
+                    <path d="M3.25 20a6.25 6.25 0 0 1 12.5 0" stroke="currentColor" stroke-width="1.9" stroke-linecap="round"/>
+                    <path d="M17.4 9.5a2.8 2.8 0 1 0 0-5.6" stroke="currentColor" stroke-width="1.9" stroke-linecap="round"/>
+                    <path d="M18.75 19.2a5.25 5.25 0 0 0-3.2-4.82" stroke="currentColor" stroke-width="1.9" stroke-linecap="round"/>
+                </svg>
+                <h1>ユーザ管理</h1>
+            </div>
+            <p>システムに登録されているユーザの情報を管理できます。</p>
+        </div>
 
-        <tr th:each="user : ${users}" class="table-row">
-            <th scope="row" class="table-cell font-medium"><label class="userId" th:text="${user.userId}"></label></th>
-            <td class="table-cell"><input class="userName" type="text" th:value="${user.userName}"></td>
-            <td class="table-cell"><input class="email" type="text" th:value="${user.email}"></td>
-            <td class="table-cell"><input class="password" type="password" placeholder="********" maxlength="10"></td>
-            <td class="table-cell"><input class="isAdmin" type="checkbox" th:checked="${user.isAdmin}"></td>
-            <td class="table-cell">
-                <button class="update-button" onclick="updateUser(event)">更新</button>
-                <button class="delete-button" onclick="deleteUser(event)">削除</button>
-        </tr>
+        <div class="header-actions">
+            <div class="current-user">
+                <span class="current-user-avatar" th:text="${#strings.substring(#authentication.principal.username, 0, 1)}">T</span>
+                <span class="current-user-name" th:text="${#authentication.principal.username}">テスト 太郎</span>
+                <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+                    <path d="m7 10 5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </div>
+            <button type="button" class="primary-action-button" onclick="openCreateUserModal()">
+                <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+                    <path d="M12 5v14M5 12h14" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                </svg>
+                <span>ユーザを追加</span>
+            </button>
+        </div>
+    </header>
 
-        </tbody>
-    </table>
+    <section class="user-filter-panel" aria-label="ユーザ検索">
+        <label class="search-control" for="userSearch">
+            <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+                <path d="m20 20-4.35-4.35M18 11a7 7 0 1 1-14 0 7 7 0 0 1 14 0Z" stroke="currentColor" stroke-width="1.9" stroke-linecap="round"/>
+            </svg>
+            <input id="userSearch" type="search" placeholder="ユーザ名、メールアドレス、ユーザIDで検索" autocomplete="off">
+        </label>
+        <label class="permission-control" for="permissionFilter">
+            <select id="permissionFilter">
+                <option value="all">すべての権限</option>
+                <option value="admin">管理者</option>
+                <option value="general">一般ユーザ</option>
+            </select>
+        </label>
+    </section>
+
+    <section class="user-table-card" aria-label="ユーザ一覧">
+        <div class="user-table-scroll">
+            <table class="user-table">
+                <thead>
+                <tr>
+                    <th scope="col">ユーザID</th>
+                    <th scope="col">ユーザ名</th>
+                    <th scope="col">メールアドレス</th>
+                    <th scope="col">権限</th>
+                    <th scope="col">管理者</th>
+                    <th scope="col">操作</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="user : ${users}"
+                    class="user-row"
+                    th:attr="data-user-id=${user.userId}, data-user-name=${user.userName}, data-email=${user.email}, data-role=${user.isAdmin ? 'admin' : 'general'}">
+                    <th scope="row" class="user-id-cell">
+                        <span class="user-id" th:text="${user.userId}">f3d6bcdc-6c32-45b6-9aea-1aa6d36b6b17</span>
+                        <button type="button" class="copy-id-button" onclick="copyUserId(event)" aria-label="ユーザIDをコピー" title="ユーザIDをコピー">
+                            <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+                                <path d="M8 8.75A2.75 2.75 0 0 1 10.75 6h6.5A2.75 2.75 0 0 1 20 8.75v6.5A2.75 2.75 0 0 1 17.25 18h-6.5A2.75 2.75 0 0 1 8 15.25v-6.5Z" stroke="currentColor" stroke-width="1.8"/>
+                                <path d="M6 14.75h-.25A2.75 2.75 0 0 1 3 12V5.75A2.75 2.75 0 0 1 5.75 3H12a2.75 2.75 0 0 1 2.75 2.75V6" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+                            </svg>
+                        </button>
+                    </th>
+                    <td class="user-name-cell" th:text="${user.userName}">テスト 太郎</td>
+                    <td th:text="${user.email}">test@solxyz.co.jp</td>
+                    <td>
+                        <span class="role-badge" th:classappend="${user.isAdmin} ? ' is-admin' : ' is-general'"
+                              th:text="${user.isAdmin ? '管理者' : '一般ユーザ'}">一般ユーザ</span>
+                    </td>
+                    <td class="admin-state-cell">
+                        <span class="admin-check" th:if="${user.isAdmin}" aria-label="管理者">
+                            <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+                                <path d="m7 12.5 3.2 3.2L17 8.9" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+                            </svg>
+                        </span>
+                        <span class="admin-empty" th:unless="${user.isAdmin}" aria-label="一般ユーザ"></span>
+                    </td>
+                    <td>
+                        <div class="row-actions">
+                            <button type="button" class="outline-action-button edit-action" onclick="openEditUserModal(event)">
+                                <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+                                    <path d="M4.75 19.25h4.5L18.4 10.1a2.12 2.12 0 0 0-3-3L6.25 16.25l-1.5 3Z" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+                                    <path d="m13.75 8.75 1.5 1.5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+                                </svg>
+                                <span>編集</span>
+                            </button>
+                            <button type="button" class="outline-action-button delete-action" onclick="deleteUser(event)">
+                                <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+                                    <path d="M5 7h14M10 11v5M14 11v5M8 7l.5 12h7L16 7M9.5 7V5.5A1.5 1.5 0 0 1 11 4h2a1.5 1.5 0 0 1 1.5 1.5V7" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+                                </svg>
+                                <span>削除</span>
+                            </button>
+                        </div>
+                    </td>
+                </tr>
+                <tr id="noResultsRow" class="no-results-row" hidden>
+                    <td colspan="6">条件に一致するユーザはいません。</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+        <div class="pagination-bar" aria-label="ページ送り">
+            <button type="button" class="pagination-button" disabled aria-label="前のページ">
+                <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+                    <path d="m15 18-6-6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </button>
+            <button type="button" class="pagination-button is-current" aria-current="page">1</button>
+            <button type="button" class="pagination-button" disabled aria-label="次のページ">
+                <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+                    <path d="m9 6 6 6-6 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </button>
+        </div>
+    </section>
+
+    <aside class="permission-note">
+        <div class="permission-note-icon" aria-hidden="true">i</div>
+        <div>
+            <h2>ユーザ権限について</h2>
+            <p>・管理者：すべての機能を利用できます。ユーザの追加・編集・削除が可能です。</p>
+            <p>・一般ユーザ：書籍の検索、貸出、カートの利用など、一般的な機能のみ利用できます。</p>
+        </div>
+    </aside>
+</main>
+
+<div id="user-modal" class="modal user-modal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog user-modal-dialog" role="dialog" aria-modal="true" aria-labelledby="user-modal-title">
+        <div class="modal-content user-modal-content">
+            <div class="modal-header user-modal-header">
+                <h2 id="user-modal-title" class="modal-title">ユーザを追加</h2>
+                <button type="button" class="modal-close user-modal-close" onclick="closeUserModal()" aria-label="閉じる">
+                    <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+                        <path d="m6 6 12 12M18 6 6 18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="modal-body user-modal-body">
+                <input type="hidden" id="modalUserId">
+                <label for="modalUserName">
+                    ユーザ名
+                    <input id="modalUserName" type="text" placeholder="田中 太郎" autocomplete="name">
+                </label>
+                <label for="modalEmail">
+                    メールアドレス
+                    <input id="modalEmail" type="email" placeholder="name@solxyz.co.jp" autocomplete="email">
+                </label>
+                <label for="modalPassword">
+                    パスワード
+                    <input id="modalPassword" type="password" placeholder="初期パスワード" maxlength="100" autocomplete="new-password">
+                </label>
+                <label class="admin-toggle" for="modalIsAdmin">
+                    <input id="modalIsAdmin" type="checkbox">
+                    <span>管理者として登録する</span>
+                </label>
+            </div>
+            <div class="modal-footer user-modal-footer">
+                <button type="button" class="secondary-action-button" onclick="closeUserModal()">キャンセル</button>
+                <button type="button" id="modalSubmitButton" class="primary-action-button" onclick="submitUserForm()">追加</button>
+            </div>
+        </div>
+    </div>
 </div>
 </body>
 </html>

--- a/src/test/java/jp/co/solxyz/jsn/springbootadvincedexam/app/admin/user/controller/UserManagementTemplateTest.java
+++ b/src/test/java/jp/co/solxyz/jsn/springbootadvincedexam/app/admin/user/controller/UserManagementTemplateTest.java
@@ -66,6 +66,12 @@ class UserManagementTemplateTest {
                 .andExpect(MockMvcResultMatchers.content().string(containsString("ユーザを追加")))
                 .andExpect(MockMvcResultMatchers.content().string(containsString("aria-label=\"ユーザ検索\"")))
                 .andExpect(MockMvcResultMatchers.content().string(containsString("aria-label=\"権限フィルター\"")))
+                .andExpect(MockMvcResultMatchers.content().string(containsString("trapUserModalFocus")))
+                .andExpect(MockMvcResultMatchers.content().string(containsString("event.key !== \"Tab\"")))
+                .andExpect(MockMvcResultMatchers.content().string(containsString("userModalTrigger.focus({preventScroll: true})")))
+                .andExpect(MockMvcResultMatchers.content().string(containsString("手動でコピーしてください")))
+                .andExpect(MockMvcResultMatchers.content().string(containsString("document.execCommand(\"copy\")")))
+                .andExpect(MockMvcResultMatchers.content().string(containsString("textarea.parentNode")))
                 .andExpect(MockMvcResultMatchers.content().string(containsString("admin@solxyz.co.jp")))
                 .andExpect(MockMvcResultMatchers.content().string(containsString("一般ユーザ")));
     }

--- a/src/test/java/jp/co/solxyz/jsn/springbootadvincedexam/app/admin/user/controller/UserManagementTemplateTest.java
+++ b/src/test/java/jp/co/solxyz/jsn/springbootadvincedexam/app/admin/user/controller/UserManagementTemplateTest.java
@@ -2,11 +2,15 @@ package jp.co.solxyz.jsn.springbootadvincedexam.app.admin.user.controller;
 
 import jp.co.solxyz.jsn.springbootadvincedexam.app.admin.user.model.UserManagementModel;
 import jp.co.solxyz.jsn.springbootadvincedexam.app.admin.user.service.UserManagementService;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -15,7 +19,11 @@ import org.springframework.web.context.WebApplicationContext;
 
 import java.util.List;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
@@ -59,20 +67,36 @@ class UserManagementTemplateTest {
                 false);
         when(userManagementService.getAllUsers()).thenReturn(List.of(admin, user));
 
-        mockMvc.perform(MockMvcRequestBuilders.get("/admin/management/user"))
+        MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/admin/management/user"))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.view().name("admin/user-management"))
-                .andExpect(MockMvcResultMatchers.content().string(containsString("user-management-main")))
-                .andExpect(MockMvcResultMatchers.content().string(containsString("ユーザを追加")))
-                .andExpect(MockMvcResultMatchers.content().string(containsString("aria-label=\"ユーザ検索\"")))
-                .andExpect(MockMvcResultMatchers.content().string(containsString("aria-label=\"権限フィルター\"")))
-                .andExpect(MockMvcResultMatchers.content().string(containsString("trapUserModalFocus")))
-                .andExpect(MockMvcResultMatchers.content().string(containsString("event.key !== \"Tab\"")))
-                .andExpect(MockMvcResultMatchers.content().string(containsString("userModalTrigger.focus({preventScroll: true})")))
-                .andExpect(MockMvcResultMatchers.content().string(containsString("手動でコピーしてください")))
-                .andExpect(MockMvcResultMatchers.content().string(containsString("document.execCommand(\"copy\")")))
-                .andExpect(MockMvcResultMatchers.content().string(containsString("textarea.parentNode")))
-                .andExpect(MockMvcResultMatchers.content().string(containsString("admin@solxyz.co.jp")))
-                .andExpect(MockMvcResultMatchers.content().string(containsString("一般ユーザ")));
+                .andReturn();
+
+        Document document = Jsoup.parse(result.getResponse().getContentAsString());
+        Element userModal = requireElement(document, "#user-modal");
+        assertThat(userModal.hasClass("modal"), is(true));
+        assertThat(userModal.hasClass("user-modal"), is(true));
+        assertThat(userModal.attr("tabindex"), equalTo("-1"));
+        assertThat(userModal.attr("aria-hidden"), equalTo("true"));
+
+        Element userDialog = requireElement(document, "#user-modal [role=dialog]");
+        assertThat(userDialog.attr("aria-modal"), equalTo("true"));
+        assertThat(userDialog.attr("aria-labelledby"), equalTo("user-modal-title"));
+
+        assertThat(requireElement(document, "#userSearch").attr("aria-label"), equalTo("ユーザ検索"));
+        assertThat(requireElement(document, "#permissionFilter").attr("aria-label"), equalTo("権限フィルター"));
+        requireElement(document, ".user-modal-close[aria-label='閉じる']");
+        requireElement(document, ".copy-id-button[aria-label='ユーザIDをコピー']");
+        requireElement(document, ".user-management-main");
+
+        assertThat(document.text(), containsString("ユーザを追加"));
+        assertThat(document.text(), containsString("admin@solxyz.co.jp"));
+        assertThat(document.text(), containsString("一般ユーザ"));
+    }
+
+    private static Element requireElement(Document document, String cssQuery) {
+        Element element = document.selectFirst(cssQuery);
+        assertThat(cssQuery, element, notNullValue());
+        return element;
     }
 }

--- a/src/test/java/jp/co/solxyz/jsn/springbootadvincedexam/app/admin/user/controller/UserManagementTemplateTest.java
+++ b/src/test/java/jp/co/solxyz/jsn/springbootadvincedexam/app/admin/user/controller/UserManagementTemplateTest.java
@@ -5,7 +5,6 @@ import jp.co.solxyz.jsn.springbootadvincedexam.app.admin.user.service.UserManage
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockitoAnnotations;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -37,7 +36,6 @@ class UserManagementTemplateTest {
 
     @BeforeEach
     void setUp() {
-        MockitoAnnotations.openMocks(this);
         mockMvc = MockMvcBuilders
                 .webAppContextSetup(context)
                 .apply(springSecurity())
@@ -66,6 +64,8 @@ class UserManagementTemplateTest {
                 .andExpect(MockMvcResultMatchers.view().name("admin/user-management"))
                 .andExpect(MockMvcResultMatchers.content().string(containsString("user-management-main")))
                 .andExpect(MockMvcResultMatchers.content().string(containsString("ユーザを追加")))
+                .andExpect(MockMvcResultMatchers.content().string(containsString("aria-label=\"ユーザ検索\"")))
+                .andExpect(MockMvcResultMatchers.content().string(containsString("aria-label=\"権限フィルター\"")))
                 .andExpect(MockMvcResultMatchers.content().string(containsString("admin@solxyz.co.jp")))
                 .andExpect(MockMvcResultMatchers.content().string(containsString("一般ユーザ")));
     }

--- a/src/test/java/jp/co/solxyz/jsn/springbootadvincedexam/app/admin/user/controller/UserManagementTemplateTest.java
+++ b/src/test/java/jp/co/solxyz/jsn/springbootadvincedexam/app/admin/user/controller/UserManagementTemplateTest.java
@@ -1,0 +1,72 @@
+package jp.co.solxyz.jsn.springbootadvincedexam.app.admin.user.controller;
+
+import jp.co.solxyz.jsn.springbootadvincedexam.app.admin.user.model.UserManagementModel;
+import jp.co.solxyz.jsn.springbootadvincedexam.app.admin.user.service.UserManagementService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+
+@SpringBootTest
+class UserManagementTemplateTest {
+
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private UserManagementService userManagementService;
+
+    private final WebApplicationContext context;
+
+    UserManagementTemplateTest(WebApplicationContext context) {
+        this.context = context;
+    }
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        mockMvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .apply(springSecurity())
+                .defaultRequest(MockMvcRequestBuilders.get("/")
+                        .with(user("テスト 太郎").roles("ADMIN")))
+                .build();
+    }
+
+    @Test
+    @DisplayName("ユーザ管理画面テンプレートが管理者向けに表示される")
+    void shouldRenderUserManagementTemplateForAdmin() throws Exception {
+        UserManagementModel admin = new UserManagementModel(
+                "f3d6bcdc-6c32-45b6-9aea-1aa6d36b6b13",
+                "管理 次郎",
+                "admin@solxyz.co.jp",
+                true);
+        UserManagementModel user = new UserManagementModel(
+                "f3d6bcdc-6c32-45b6-9aea-1aa6d36b6b17",
+                "テスト 太郎",
+                "test@solxyz.co.jp",
+                false);
+        when(userManagementService.getAllUsers()).thenReturn(List.of(admin, user));
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/admin/management/user"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.view().name("admin/user-management"))
+                .andExpect(MockMvcResultMatchers.content().string(containsString("user-management-main")))
+                .andExpect(MockMvcResultMatchers.content().string(containsString("ユーザを追加")))
+                .andExpect(MockMvcResultMatchers.content().string(containsString("admin@solxyz.co.jp")))
+                .andExpect(MockMvcResultMatchers.content().string(containsString("一般ユーザ")));
+    }
+}


### PR DESCRIPTION
## Summary

- Redesigned the admin user management screen to match the provided mockup.
- Moved add/edit flows into a modal while keeping the existing user management API calls.
- Added dedicated CSS for the new layout, search/filter controls, table, role badges, pagination, and permission note.
- Added a MockMvc template rendering test for the admin user management page.

## Validation

- `./gradlew test`
