### PR TITLE
[codex] Update book management UI

### DIFF
--- a/src/main/resources/static/css/management.css
+++ b/src/main/resources/static/css/management.css
@@ -1,113 +1,601 @@
-input, textarea {
-    resize: none;
-    border: none;
-    border-bottom: 1px solid #808080;
-    width: 98%;
-    margin-bottom: 2px;
+.book-management-screen {
+    background:
+        linear-gradient(135deg, #f8fbff 0%, #f1f6ff 52%, #f8fbff 100%);
 }
 
-textarea {
-    height: 20vh;
+.book-management-main {
+    width: min(1290px, calc(100vw - 376px));
+    margin: 52px 48px 64px 328px;
 }
 
-input:focus, textarea:focus {
-    opacity: 0.8;
-    border: none;
-    outline: none;
-    border-bottom: 1px solid #808080;
-    background-color: #D3D3D3;
-}
-
-.section-title {
-    text-align: center;
-    letter-spacing: 0.3em;
-}
-
-.container-group{
+.management-page-header {
     display: flex;
-    justify-content: center;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 24px;
+    margin-bottom: 28px;
+}
+
+.management-page-header h1 {
+    margin: 0 0 10px;
+    color: #162033;
+    font-size: 31px;
+    line-height: 1.25;
+    font-weight: 800;
+    letter-spacing: 0;
+}
+
+.management-page-header p {
+    margin: 0;
+    color: #5f6f85;
+    font-size: 16px;
+    font-weight: 700;
+}
+
+.management-add-button {
+    display: inline-flex;
     align-items: center;
-    flex-wrap: wrap;
+    justify-content: center;
+    gap: 10px;
+    width: auto;
+    max-width: none;
+    min-height: 44px;
+    margin: 0;
+    padding: 0 22px;
+    color: #ffffff;
+    background: #2f64e5;
+    border: 1px solid #2f64e5;
+    border-radius: 8px;
+    box-shadow: 0 12px 22px rgba(47, 100, 229, 0.22);
+    font-size: 15px;
+    font-weight: 800;
+    opacity: 1;
+}
+
+.management-add-button:hover {
+    background: #2457d2;
+}
+
+.management-add-button .material-symbols-outlined {
+    font-size: 22px;
+}
+
+.management-panel {
+    padding: 22px;
+    background: rgba(255, 255, 255, 0.94);
+    border: 1px solid #edf2f8;
+    border-radius: 8px;
+    box-shadow: 0 18px 42px rgba(25, 46, 86, 0.12);
+}
+
+.management-toolbar {
+    display: grid;
+    grid-template-columns: minmax(280px, 1fr) 234px 264px;
+    gap: 16px;
+    margin-bottom: 22px;
+}
+
+.search-control,
+.select-control {
+    position: relative;
+    display: flex;
+    align-items: center;
+    min-width: 0;
+}
+
+.search-control input,
+.select-control select {
+    width: 100%;
+    min-height: 42px;
+    margin: 0;
+    color: #162033;
+    background: #ffffff;
+    border: 1px solid #ccd6e5;
+    border-radius: 8px;
+    outline: none;
+    box-shadow: 0 2px 4px rgba(25, 46, 86, 0.03);
+    font: inherit;
+    font-size: 14px;
+    font-weight: 700;
+}
+
+.search-control input {
+    padding: 0 16px 0 42px;
+}
+
+.select-control select {
+    appearance: none;
+    padding: 0 40px 0 16px;
+}
+
+.sort-control select {
+    padding-left: 42px;
+}
+
+.search-control input::placeholder {
+    color: #7b8798;
+}
+
+.search-control input:focus,
+.select-control select:focus {
+    border-color: #2f64e5;
+    box-shadow: 0 0 0 3px rgba(47, 100, 229, 0.14);
+}
+
+.control-icon,
+.sort-icon {
+    position: absolute;
+    z-index: 1;
+    color: #6b7a90;
+    pointer-events: none;
+}
+
+.search-control .control-icon {
+    left: 14px;
+}
+
+.select-control .control-icon {
+    right: 12px;
+    font-size: 22px;
+}
+
+.sort-icon {
+    left: 14px;
+    font-size: 20px;
 }
 
 .book-container {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: flex-start;
-    width: 100%;
-}
-
-.book-form {
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-    padding: 3%;
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 20px;
 }
 
 .book-item {
-    flex: 0 0 24%;
-    border: 0.5px solid #dfdfdf;
-    border-radius: 5px;
-    width: 100%;
-    margin: 10px 5px;
-    box-shadow: 5px 5px 10px rgba(0, 0, 0, 0.1);
-}
-
-.book-field {
     display: flex;
+    min-width: 0;
+    overflow: hidden;
     flex-direction: column;
-    align-items: flex-start;
-    padding: 5px;
-    border-bottom: 1px solid #808080;
+    background: #ffffff;
+    border: 1px solid #e2e8f2;
+    border-radius: 8px;
+    box-shadow: 0 10px 24px rgba(25, 46, 86, 0.1);
 }
 
-.field-header {
-     display: flex;
-     position: relative;
-     align-items: center;
-}
-
-.field-header label {
-    font-size: 70%;
-    width: auto;
-}
-
-.field-header label,
-.field-header .toggle {
-    display: inline-block;
-    position: sticky;
-    top: 0;
-    background: inherit;
-    z-index: 2;
-}
-
-.field-body{
-    display: flex;
-    position: relative;
-    align-items: center;
-    overflow: auto;
-    width: 100%;
-}
-
-.field-body .description {
-    position: absolute;
-    z-index: 1;
-    top:0;
-    left:0;
-}
-
-.book-actions {
-    display: flex;
-    justify-content: center;
-}
-
-.hidden{
+.book-item[hidden] {
     display: none;
 }
 
-.material-symbols-outlined.add_circle {
-    position: fixed;
-    right: 5vw;
-    bottom: 5vh;
-    transform: scale(2);
+.book-card-summary {
+    display: grid;
+    grid-template-columns: 104px minmax(0, 1fr);
+    gap: 18px;
+    min-height: 148px;
+    padding: 22px 22px 14px;
+}
+
+.management-cover-frame {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 92px;
+    height: 126px;
+    background: #f8fafc;
+    border: 1px solid #edf2f8;
+    box-shadow: 0 8px 18px rgba(25, 46, 86, 0.08);
+    overflow: hidden;
+}
+
+.management-cover {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+}
+
+.cover-placeholder {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 8px;
+    color: #536176;
+    background: #edf2f7;
+    font-weight: 800;
+    text-align: center;
+}
+
+.cover-placeholder-text {
+    overflow-wrap: anywhere;
+    font-size: 11px;
+    line-height: 1.1;
+    letter-spacing: 0;
+}
+
+.management-cover-frame.has-cover .cover-placeholder {
+    display: none;
+}
+
+.book-card-heading {
+    min-width: 0;
+    padding-top: 16px;
+}
+
+.book-card-kicker {
+    display: block;
+    margin-bottom: 6px;
+    color: #5f6f85;
+    font-size: 13px;
+    font-weight: 800;
+}
+
+.isbn {
+    display: block;
+    color: #162033;
+    font-size: 18px;
+    line-height: 1.45;
+    font-weight: 700;
+    overflow-wrap: anywhere;
+}
+
+.book-field {
+    display: grid;
+    grid-template-columns: 108px minmax(0, 1fr);
+    align-items: center;
+    gap: 12px;
+    min-height: 52px;
+    padding: 0 22px;
+    border-top: 1px solid #e5ebf3;
+}
+
+.field-header {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    min-width: 0;
+    color: #536176;
+}
+
+.field-header .material-symbols-outlined {
+    width: 20px;
+    font-size: 20px;
+    color: #64758c;
+}
+
+.field-header label {
+    font-size: 14px;
+    font-weight: 800;
+    white-space: nowrap;
+}
+
+.field-body {
+    display: flex;
+    align-items: center;
+    min-width: 0;
+    color: #162033;
+    font-size: 15px;
+    font-weight: 700;
+}
+
+.display-input {
+    width: 100%;
+    min-width: 0;
+    margin: 0;
+    padding: 7px 0;
+    color: #162033;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 6px;
+    outline: none;
+    font: inherit;
+    font-weight: 700;
+}
+
+.display-input:focus {
+    padding-right: 8px;
+    padding-left: 8px;
+    background: #f8fbff;
+    border-color: #9ab3f2;
+    box-shadow: 0 0 0 3px rgba(47, 100, 229, 0.12);
+}
+
+.description-toggle {
+    width: auto;
+    max-width: none;
+    min-height: auto;
+    margin: 0;
+    padding: 6px 0;
+    color: #162033;
+    background: transparent;
+    border: 0;
+    border-radius: 6px;
+    font: inherit;
+    font-weight: 700;
+    opacity: 1;
+}
+
+.description-toggle:hover {
+    color: #2f64e5;
+}
+
+.description-panel {
+    padding: 0 22px;
+}
+
+.description {
+    width: 100%;
+    min-height: 120px;
+    margin: 12px 0 16px;
+    padding: 12px;
+    color: #162033;
+    background: #f8fbff;
+    border: 1px solid #ccd6e5;
+    border-radius: 8px;
+    outline: none;
+    font: inherit;
+    font-size: 14px;
+    line-height: 1.7;
+    resize: vertical;
+}
+
+.description:focus {
+    border-color: #2f64e5;
+    box-shadow: 0 0 0 3px rgba(47, 100, 229, 0.14);
+}
+
+.hidden {
+    display: none;
+}
+
+.stock-field {
+    gap: 4px;
+}
+
+.stock-input {
+    flex: 0 0 48px;
+    width: 48px;
+    text-align: left;
+}
+
+.stock-input::-webkit-outer-spin-button,
+.stock-input::-webkit-inner-spin-button {
+    margin: 0;
+    appearance: none;
+}
+
+.book-actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 30px;
+    margin-top: auto;
+    padding: 22px 34px 24px;
+    border-top: 1px solid #e5ebf3;
+}
+
+.book-action-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    width: 100%;
+    max-width: none;
+    min-height: 46px;
+    margin: 0;
+    padding: 0 14px;
+    background: #ffffff;
+    border-radius: 8px;
+    font-size: 15px;
+    font-weight: 800;
+    opacity: 1;
+}
+
+.book-action-button .material-symbols-outlined {
+    font-size: 20px;
+}
+
+.update-button {
+    color: #2fa856;
+    border: 1px solid #2fa856;
+}
+
+.update-button:hover {
+    color: #ffffff;
+    background: #2fa856;
+}
+
+.delete-button {
+    color: #ff3f3f;
+    border: 1px solid #ff3f3f;
+}
+
+.delete-button:hover {
+    color: #ffffff;
+    background: #ff3f3f;
+}
+
+.management-empty-state {
+    margin: 28px 0 4px;
+    color: #536176;
+    font-weight: 800;
+    text-align: center;
+}
+
+.management-result-footer {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 18px;
+    color: #5f6f85;
+    font-size: 14px;
+    font-weight: 800;
+}
+
+.book-management-modal .modal-dialog {
+    width: min(620px, calc(100vw - 36px));
+}
+
+.book-management-modal .modal-content {
+    width: 100%;
+    max-width: none;
+    padding: 0;
+    border-radius: 8px;
+    box-shadow: 0 24px 60px rgba(5, 19, 43, 0.28);
+}
+
+.book-management-modal .modal-header,
+.book-management-modal .modal-footer {
+    padding: 20px 24px;
+}
+
+.book-management-modal .modal-body {
+    padding: 22px 24px;
+}
+
+.book-management-modal .modal-title {
+    margin: 0;
+    color: #162033;
+    font-size: 22px;
+    font-weight: 800;
+}
+
+.book-management-modal .modal-close {
+    max-width: none;
+    margin: 0;
+    opacity: 1;
+}
+
+.book-form {
+    display: grid;
+    gap: 10px;
+}
+
+.book-form label {
+    color: #536176;
+    font-size: 14px;
+    font-weight: 800;
+}
+
+.book-form input,
+.book-form textarea {
+    width: 100%;
+    margin: 0 0 8px;
+    padding: 11px 12px;
+    color: #162033;
+    background: #ffffff;
+    border: 1px solid #ccd6e5;
+    border-radius: 8px;
+    outline: none;
+    font: inherit;
+    font-size: 15px;
+}
+
+.book-form textarea {
+    min-height: 120px;
+    resize: vertical;
+}
+
+.book-form input:focus,
+.book-form textarea:focus {
+    border-color: #2f64e5;
+    box-shadow: 0 0 0 3px rgba(47, 100, 229, 0.14);
+}
+
+.book-management-modal .modal-footer {
+    justify-content: flex-end;
+    gap: 14px;
+}
+
+.book-management-modal .cancel-button,
+.book-management-modal .add-button {
+    width: auto;
+    max-width: none;
+    min-height: 42px;
+    margin: 0;
+    padding: 0 20px;
+    border-radius: 8px;
+    font-size: 15px;
+    font-weight: 800;
+    opacity: 1;
+}
+
+.book-management-modal .cancel-button {
+    color: #536176;
+    background: #ffffff;
+    border: 1px solid #ccd6e5;
+}
+
+.book-management-modal .cancel-button:hover {
+    color: #162033;
+    background: #f8fbff;
+}
+
+.book-management-modal .add-button {
+    color: #ffffff;
+    background: #2f64e5;
+    border: 1px solid #2f64e5;
+}
+
+.book-management-modal .add-button:hover {
+    background: #2457d2;
+}
+
+.required {
+    color: #e52f45;
+}
+
+@media (max-width: 1280px) {
+    .book-container {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 1080px) {
+    .management-toolbar {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 960px) {
+    .book-management-main {
+        width: auto;
+        margin: 32px 16px 48px;
+    }
+
+    .management-page-header {
+        flex-direction: column;
+    }
+
+    .management-add-button {
+        width: 100%;
+    }
+}
+
+@media (max-width: 720px) {
+    .management-panel {
+        padding: 16px;
+    }
+
+    .book-container {
+        grid-template-columns: 1fr;
+    }
+
+    .book-card-summary {
+        grid-template-columns: 92px minmax(0, 1fr);
+        padding: 18px 18px 12px;
+    }
+
+    .management-cover-frame {
+        width: 80px;
+        height: 110px;
+    }
+
+    .book-field {
+        grid-template-columns: 96px minmax(0, 1fr);
+        padding: 0 18px;
+    }
+
+    .book-actions {
+        gap: 14px;
+        padding: 18px;
+    }
 }

--- a/src/main/resources/templates/admin/book-management.html
+++ b/src/main/resources/templates/admin/book-management.html
@@ -5,9 +5,9 @@
     <meta charset="UTF-8">
     <title>書籍管理</title>
     <link th:href="@{/css/main.css}" rel="stylesheet">
-    <link th:href="@{/css/management.css}" rel="stylesheet">
     <link th:href="@{/css/button.css}" rel="stylesheet">
     <link th:href="@{/css/modal.css}" rel="stylesheet">
+    <link th:href="@{/css/management.css}" rel="stylesheet">
 
     <link rel="stylesheet"
           href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
@@ -96,16 +96,15 @@ function deleteBook(event) {
     });
 }
 
-    </script>
-    <script th:inline="javascript">
 function toggleDescription(event) {
-    const textarea = event.target.parentElement.parentElement.querySelector('textarea');
+    const button = event.currentTarget;
+    const textarea = button.closest(".book-item").querySelector(".description");
     textarea.classList.toggle("hidden");
 
     if (textarea.classList.contains("hidden")) {
-        event.target.textContent = "表示";
+        button.querySelector(".description-toggle-text").textContent = "表示";
     } else {
-        event.target.textContent = "非表示";
+        button.querySelector(".description-toggle-text").textContent = "非表示";
     }
 }
 
@@ -121,103 +120,273 @@ function clearInputs() {
   });
 }
 
+function showCoverPlaceholder(img) {
+  const frame = img.closest(".management-cover-frame");
+  img.hidden = true;
+  img.removeAttribute("src");
+  img.removeAttribute("alt");
+  frame?.classList.remove("has-cover");
+}
+
+function applyCoverImage(img, coverUrl) {
+  if (!coverUrl) {
+    showCoverPlaceholder(img);
+    return;
+  }
+
+  const frame = img.closest(".management-cover-frame");
+  img.onerror = () => showCoverPlaceholder(img);
+  img.hidden = false;
+  frame?.classList.add("has-cover");
+  img.src = coverUrl;
+  img.alt = img.getAttribute("data-cover-title") + " の書影";
+}
+
+async function hydrateManagementCovers() {
+  const coverImages = Array.from(document.querySelectorAll("[data-cover-isbn]"));
+  const isbnList = [...new Set(coverImages.map(img => img.getAttribute("data-cover-isbn")).filter(Boolean))];
+  const openBdBatchSize = 20;
+
+  for (let index = 0; index < isbnList.length; index += openBdBatchSize) {
+    const batch = isbnList.slice(index, index + openBdBatchSize);
+    try {
+      const response = await fetch(`/api/book/covers?isbn=${batch.map(encodeURIComponent).join(",")}`);
+      if (!response.ok) {
+        throw new Error("cover request failed");
+      }
+      const coverUrls = await response.json();
+      batch.forEach(isbn => {
+        document.querySelectorAll(`[data-cover-isbn="${isbn}"]`).forEach(img => {
+          applyCoverImage(img, coverUrls[isbn]);
+        });
+      });
+    } catch (error) {
+      batch.forEach(isbn => {
+        document.querySelectorAll(`[data-cover-isbn="${isbn}"]`).forEach(showCoverPlaceholder);
+      });
+      console.warn("openBDから書影を取得できませんでした。", error);
+    }
+  }
+}
+
+function normalizeBookText(value) {
+  return (value ?? "").toString().trim().toLowerCase();
+}
+
+function applyBookControls() {
+  const grid = document.getElementById("book-grid");
+  const query = normalizeBookText(document.getElementById("book-search")?.value);
+  const filter = document.getElementById("book-filter")?.value || "all";
+  const sort = document.getElementById("book-sort")?.value || "created-desc";
+  const items = Array.from(document.querySelectorAll(".book-item"));
+  let visibleCount = 0;
+
+  items.forEach(item => {
+    const stock = Number(item.dataset.stock || 0);
+    const haystack = normalizeBookText([
+      item.dataset.isbn,
+      item.dataset.displayedIsbn,
+      item.dataset.title,
+      item.dataset.author,
+      item.dataset.publisher
+    ].join(" "));
+    const matchesQuery = query === "" || haystack.includes(query);
+    const matchesFilter =
+      filter === "all" ||
+      (filter === "in-stock" && stock > 0) ||
+      (filter === "out-of-stock" && stock === 0);
+    const isVisible = matchesQuery && matchesFilter;
+
+    item.hidden = !isVisible;
+    if (isVisible) {
+      visibleCount += 1;
+    }
+  });
+
+  const originalOrder = (a, b) => Number(a.dataset.index || 0) - Number(b.dataset.index || 0);
+
+  items.sort((a, b) => {
+    if (sort === "created-asc") {
+      return (a.dataset.createdAt || "").localeCompare(b.dataset.createdAt || "") || originalOrder(a, b);
+    }
+    if (sort === "title-asc") {
+      return (a.dataset.title || "").localeCompare(b.dataset.title || "", "ja") || originalOrder(a, b);
+    }
+    if (sort === "stock-desc") {
+      return Number(b.dataset.stock || 0) - Number(a.dataset.stock || 0) || originalOrder(a, b);
+    }
+    return (b.dataset.createdAt || "").localeCompare(a.dataset.createdAt || "") || originalOrder(a, b);
+  });
+
+  items.forEach(item => grid.appendChild(item));
+  document.getElementById("management-result-count").textContent = `全${visibleCount}件`;
+  document.getElementById("management-empty-state").hidden = visibleCount !== 0;
+}
+
+window.addEventListener("DOMContentLoaded", () => {
+  document.getElementById("book-search")?.addEventListener("input", applyBookControls);
+  document.getElementById("book-filter")?.addEventListener("change", applyBookControls);
+  document.getElementById("book-sort")?.addEventListener("change", applyBookControls);
+  applyBookControls();
+  hydrateManagementCovers();
+});
+
     </script>
 </head>
 
-<body>
+<body class="book-management-screen">
 <div id="foo" th:replace="~{common/nav-bar :: bar}"></div>
-<div class="container">
-
-</div>
-<h2 class="section-title">書籍一覧</h2>
-<div class="container-group">
-    <div class="book-container">
-        <div th:each="book : ${books}" class="book-item">
-            <div class="book-field">
-                <div class="field-header">
-                    <label>ISBN</label>
-                </div>
-                <div class="field-body">
-                <span class="isbn" th:text="${book.displayedIsbn}"
-                      th:attr="data-isbn=${book.isbn}"></span>
-                </div>
-            </div>
-
-            <div class="book-field">
-                <div class="field-header">
-                    <label>書籍名</label>
-                </div>
-                <div class="field-body">
-                    <input class="title" type="text" th:value="${book.title}">
-                </div>
-            </div>
-
-            <div class="book-field">
-                <div class="field-header">
-                    <label>出版社</label>
-                </div>
-                <div class="field-body">
-                    <input class="publisher" type="text" th:value="${book.publisher}">
-                </div>
-            </div>
-
-            <div class="book-field">
-                <div class="field-header">
-                    <label>著者名</label>
-                </div>
-                <div class="field-body">
-                    <input class="author" type="text" th:value="${book.author}">
-                </div>
-            </div>
-
-            <div class="book-field">
-                <div class="field-header">
-                    <label>説明</label>
-                    <button class="toggle" onclick="toggleDescription(event)">表示</button>
-                </div>
-                <div class="field-body" style="min-height: 10vh;">
-                    <textarea class="hidden description" th:text="${book.description}"></textarea>
-                </div>
-            </div>
-
-            <div class="book-field">
-                <div class="field-header">
-                    <label>在庫</label>
-                </div>
-                <div class="field-body">
-                    <input class="stock" type="number" th:value="${book.Stock}">
-                </div>
-            </div>
-
-            <div class="book-field">
-                <div class="field-header">
-                    <label>作成日</label>
-                </div>
-                <div class="field-body">
-                    <span class="createdAt"
-                          th:text="${#temporals.format(book.createdAt, 'yyyy年M月d日 H時m分s秒')}"></span>
-                </div>
-            </div>
-
-            <div class="book-field">
-                <div class="field-header">
-                    <label>更新日</label>
-                </div>
-                <div class="field-body">
-                    <span th:text="${#temporals.format(book.updatedAt, 'yyyy年M月d日 H時m分s秒')}"></span>
-                </div>
-            </div>
-
-            <div class="book-actions">
-                <button class="update-button" onclick="updateBook(event)">更新</button>
-                <button class="delete-button" onclick="deleteBook(event)">削除</button>
-            </div>
+<main class="book-management-main">
+    <section class="management-page-header">
+        <div>
+            <h1>書籍管理</h1>
+            <p>登録されている書籍の情報を管理できます。</p>
         </div>
-    </div>
-</div>
+        <button type="button" class="management-add-button" data-modal-target="default-modal" data-modal-toggle="default-modal">
+            <span class="material-symbols-outlined" aria-hidden="true">add</span>
+            <span>書籍を追加</span>
+        </button>
+    </section>
+
+    <section class="management-panel" aria-label="書籍管理一覧">
+        <div class="management-toolbar">
+            <label class="search-control" for="book-search">
+                <span class="material-symbols-outlined control-icon" aria-hidden="true">search</span>
+                <input id="book-search" type="search" placeholder="書籍名、著者名、ISBNで検索">
+            </label>
+            <label class="select-control" for="book-filter">
+                <select id="book-filter" aria-label="在庫で絞り込み">
+                    <option value="all">すべての書籍</option>
+                    <option value="in-stock">在庫あり</option>
+                    <option value="out-of-stock">在庫なし</option>
+                </select>
+                <span class="material-symbols-outlined control-icon" aria-hidden="true">expand_more</span>
+            </label>
+            <label class="select-control sort-control" for="book-sort">
+                <span class="material-symbols-outlined sort-icon" aria-hidden="true">tune</span>
+                <select id="book-sort" aria-label="表示順">
+                    <option value="created-desc">表示順：登録日（新しい順）</option>
+                    <option value="created-asc">表示順：登録日（古い順）</option>
+                    <option value="title-asc">表示順：書籍名</option>
+                    <option value="stock-desc">表示順：在庫数</option>
+                </select>
+                <span class="material-symbols-outlined control-icon" aria-hidden="true">expand_more</span>
+            </label>
+        </div>
+
+        <div id="book-grid" class="book-container" aria-live="polite">
+            <article th:each="book, bookStat : ${books}" class="book-item"
+                     th:attr="data-index=${bookStat.index}, data-isbn=${book.isbn}, data-displayed-isbn=${book.displayedIsbn}, data-title=${book.title}, data-author=${book.author}, data-publisher=${book.publisher}, data-stock=${book.stock}, data-created-at=${#temporals.format(book.createdAt, 'yyyy/MM/dd HH:mm:ss')}">
+                <div class="book-card-summary">
+                    <span class="management-cover-frame">
+                        <img class="management-cover" th:attr="data-cover-isbn=${book.isbn}, data-cover-title=${book.title}" th:alt="${book.title + ' の書影'}" loading="lazy" hidden>
+                        <span class="cover-placeholder" aria-hidden="true">
+                            <span class="cover-placeholder-text">NO IMAGE</span>
+                        </span>
+                    </span>
+                    <div class="book-card-heading">
+                        <span class="book-card-kicker">ISBN</span>
+                        <span class="isbn" th:text="${book.displayedIsbn}" th:attr="data-isbn=${book.isbn}"></span>
+                    </div>
+                </div>
+
+                <div class="book-field">
+                    <div class="field-header">
+                        <span class="material-symbols-outlined" aria-hidden="true">menu_book</span>
+                        <label>書籍名</label>
+                    </div>
+                    <div class="field-body">
+                        <input class="title display-input" type="text" th:value="${book.title}" aria-label="書籍名">
+                    </div>
+                </div>
+
+                <div class="book-field">
+                    <div class="field-header">
+                        <span class="material-symbols-outlined" aria-hidden="true">account_balance</span>
+                        <label>出版社</label>
+                    </div>
+                    <div class="field-body">
+                        <input class="publisher display-input" type="text" th:value="${book.publisher}" aria-label="出版社">
+                    </div>
+                </div>
+
+                <div class="book-field">
+                    <div class="field-header">
+                        <span class="material-symbols-outlined" aria-hidden="true">person</span>
+                        <label>著者名</label>
+                    </div>
+                    <div class="field-body">
+                        <input class="author display-input" type="text" th:value="${book.author}" aria-label="著者名">
+                    </div>
+                </div>
+
+                <div class="book-field">
+                    <div class="field-header">
+                        <span class="material-symbols-outlined" aria-hidden="true">info</span>
+                        <label>説明</label>
+                    </div>
+                    <div class="field-body">
+                        <button type="button" class="description-toggle" onclick="toggleDescription(event)">
+                            <span class="description-toggle-text">表示</span>
+                        </button>
+                    </div>
+                </div>
+                <div class="description-panel">
+                    <textarea class="hidden description" th:text="${book.description}" aria-label="説明"></textarea>
+                </div>
+
+                <div class="book-field">
+                    <div class="field-header">
+                        <span class="material-symbols-outlined" aria-hidden="true">inventory_2</span>
+                        <label>在庫数</label>
+                    </div>
+                    <div class="field-body stock-field">
+                        <input class="stock display-input stock-input" type="number" min="0" th:value="${book.stock}" aria-label="在庫数">
+                        <span>冊</span>
+                    </div>
+                </div>
+
+                <div class="book-field">
+                    <div class="field-header">
+                        <span class="material-symbols-outlined" aria-hidden="true">calendar_month</span>
+                        <label>作成日</label>
+                    </div>
+                    <div class="field-body">
+                        <span class="createdAt" th:text="${#temporals.format(book.createdAt, 'yyyy/MM/dd HH:mm:ss')}"></span>
+                    </div>
+                </div>
+
+                <div class="book-field">
+                    <div class="field-header">
+                        <span class="material-symbols-outlined" aria-hidden="true">schedule</span>
+                        <label>更新日</label>
+                    </div>
+                    <div class="field-body">
+                        <span th:text="${#temporals.format(book.updatedAt, 'yyyy/MM/dd HH:mm:ss')}"></span>
+                    </div>
+                </div>
+
+                <div class="book-actions">
+                    <button type="button" class="book-action-button update-button" onclick="updateBook(event)">
+                        <span class="material-symbols-outlined" aria-hidden="true">edit</span>
+                        <span>編集</span>
+                    </button>
+                    <button type="button" class="book-action-button delete-button" onclick="deleteBook(event)">
+                        <span class="material-symbols-outlined" aria-hidden="true">delete</span>
+                        <span>削除</span>
+                    </button>
+                </div>
+            </article>
+        </div>
+        <p id="management-empty-state" class="management-empty-state" hidden>該当する書籍がありません。</p>
+        <div class="management-result-footer">
+            <span id="management-result-count" th:text="${'全' + books.size() + '件'}">全0件</span>
+        </div>
+    </section>
+</main>
 
 <!-- Main modal -->
-<div id="default-modal" class="modal" tabindex="-1" aria-hidden="true">
+<div id="default-modal" class="modal book-management-modal" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="modal-book-title" aria-hidden="true">
     <div class="modal-dialog" data-modal-hide="default-modal">
         <!-- Modal content -->
         <div class="modal-content">
@@ -225,7 +394,7 @@ function clearInputs() {
             <div class="modal-header">
                 <h3 id="modal-book-title" class="modal-title">書籍追加</h3>
                 <button type="button" class="modal-close" data-modal-hide="default-modal" aria-label="閉じる">
-                    <span class="material-symbols-outlined modal-close-icon sr-only" data-modal-hide="default-modal">close</span>
+                    <span class="material-symbols-outlined modal-close-icon" data-modal-hide="default-modal" aria-hidden="true">close</span>
                 </button>
             </div>
             <!-- Modal body -->
@@ -252,19 +421,12 @@ function clearInputs() {
             </div>
             <!-- Modal footer -->
             <div class="modal-footer">
-                <button class="cancel-button" onclick="clearInputs()">キャンセル</button>
-                <button class="add-button" onclick="addBook()">追加</button>
+                <button type="button" class="cancel-button" data-modal-hide="default-modal" onclick="clearInputs()">キャンセル</button>
+                <button type="button" class="add-button" onclick="addBook()">追加</button>
             </div>
         </div>
     </div>
 </div>
-
 <div id="modal-overlay" class="modal-overlay"></div>
-
-<span class="material-symbols-outlined add_circle" data-modal-target="default-modal"
-      data-modal-toggle="default-modal">
-add_circle
-</span>
-
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Updated the admin book management screen to a card-based layout matching the requested mockup.
- Added client-side search, stock filtering, sorting, result counts, and book cover hydration.
- Refreshed the management CSS for the new layout, modal styling, and responsive behavior.

## Impact

Admins get a more scannable book management experience while keeping the existing add, edit, and delete API flow intact.

## Validation

- ./gradlew test
- Rendered the management screen locally and verified search, modal open/close, ordering, and no horizontal overflow.