### PR TITLE
[codex] Remove user management header nav

### DIFF
--- a/src/main/resources/static/css/user-management.css
+++ b/src/main/resources/static/css/user-management.css
@@ -1,6 +1,6 @@
 .user-management-screen {
     background:
-        linear-gradient(135deg, #f8fbff 0%, #eef5ff 48%, #f8fbff 100%);
+        linear-gradient(135deg, #f8fbff 0%, #f1f6ff 52%, #f8fbff 100%);
 }
 
 .user-management-screen button {
@@ -9,84 +9,32 @@
 }
 
 .user-management-main {
-    width: min(1230px, calc(100vw - 376px));
-    margin: 74px 48px 40px 328px;
+    width: min(1290px, calc(100vw - 376px));
+    margin: 52px 48px 64px 328px;
 }
 
 .user-management-header {
     display: flex;
     align-items: flex-start;
     justify-content: space-between;
-    gap: 32px;
-    margin-bottom: 26px;
+    gap: 24px;
+    margin-bottom: 28px;
 }
 
-.page-title-group {
-    min-width: 0;
-}
-
-.page-title-row {
-    display: flex;
-    align-items: center;
-    gap: 18px;
-    margin-bottom: 8px;
-}
-
-.page-title-icon {
-    width: 44px;
-    height: 44px;
-    flex: 0 0 auto;
-    color: #2f64e5;
-}
-
-.page-title-row h1 {
-    margin: 0;
-    color: #142033;
-    font-size: 32px;
+.user-management-header h1 {
+    margin: 0 0 10px;
+    color: #162033;
+    font-size: 31px;
     line-height: 1.25;
     font-weight: 800;
     letter-spacing: 0;
 }
 
-.page-title-group p {
+.user-management-header p {
     margin: 0;
-    color: #536176;
+    color: #5f6f85;
     font-size: 16px;
     font-weight: 700;
-}
-
-.header-actions {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-end;
-    gap: 52px;
-}
-
-.current-user {
-    display: inline-flex;
-    align-items: center;
-    gap: 12px;
-    color: #142033;
-    font-weight: 800;
-    white-space: nowrap;
-}
-
-.current-user-avatar {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 36px;
-    height: 36px;
-    color: #ffffff;
-    background: #2f64e5;
-    border-radius: 999px;
-    box-shadow: 0 8px 18px rgba(47, 100, 229, 0.24);
-}
-
-.current-user svg {
-    width: 18px;
-    height: 18px;
-    color: #536176;
 }
 
 .primary-action-button,
@@ -111,18 +59,17 @@
 }
 
 .primary-action-button {
-    min-height: 48px;
-    padding: 0 24px;
+    min-height: 44px;
+    padding: 0 22px;
     color: #ffffff;
     background: #2f64e5;
     border: 1px solid #2f64e5;
-    box-shadow: 0 10px 24px rgba(47, 100, 229, 0.22);
+    box-shadow: 0 12px 22px rgba(47, 100, 229, 0.22);
 }
 
 .primary-action-button:hover {
-    background: #1f55d6;
-    border-color: #1f55d6;
-    transform: translateY(-1px);
+    background: #2457d2;
+    border-color: #2457d2;
 }
 
 .primary-action-button svg {
@@ -584,19 +531,15 @@
 @media (max-width: 960px) {
     .user-management-main {
         width: auto;
-        margin: 28px 16px 34px;
+        margin: 32px 16px 48px;
     }
 
     .user-management-header {
         flex-direction: column;
     }
 
-    .header-actions {
+    .user-management-header .primary-action-button {
         width: 100%;
-        flex-direction: row;
-        align-items: center;
-        justify-content: space-between;
-        gap: 18px;
     }
 
     .user-filter-panel {
@@ -610,17 +553,8 @@
 }
 
 @media (max-width: 640px) {
-    .page-title-row h1 {
+    .user-management-header h1 {
         font-size: 28px;
-    }
-
-    .header-actions {
-        align-items: stretch;
-        flex-direction: column;
-    }
-
-    .current-user {
-        justify-content: flex-end;
     }
 
     .primary-action-button {

--- a/src/main/resources/templates/admin/user-management.html
+++ b/src/main/resources/templates/admin/user-management.html
@@ -270,36 +270,19 @@ document.addEventListener("DOMContentLoaded", () => {
 <body class="user-management-screen">
 <div id="foo" th:replace="~{common/nav-bar :: bar}"></div>
 <main class="user-management-main">
-    <header class="user-management-header">
-        <div class="page-title-group">
-            <div class="page-title-row">
-                <svg class="page-title-icon" aria-hidden="true" viewBox="0 0 24 24" fill="none">
-                    <path d="M9.5 12.25a4 4 0 1 0 0-8 4 4 0 0 0 0 8Z" stroke="currentColor" stroke-width="1.9"/>
-                    <path d="M3.25 20a6.25 6.25 0 0 1 12.5 0" stroke="currentColor" stroke-width="1.9" stroke-linecap="round"/>
-                    <path d="M17.4 9.5a2.8 2.8 0 1 0 0-5.6" stroke="currentColor" stroke-width="1.9" stroke-linecap="round"/>
-                    <path d="M18.75 19.2a5.25 5.25 0 0 0-3.2-4.82" stroke="currentColor" stroke-width="1.9" stroke-linecap="round"/>
-                </svg>
-                <h1>ユーザ管理</h1>
-            </div>
+    <section class="user-management-header">
+        <div>
+            <h1>ユーザ管理</h1>
             <p>システムに登録されているユーザの情報を管理できます。</p>
         </div>
 
-        <div class="header-actions">
-            <div class="current-user">
-                <span class="current-user-avatar" th:text="${#strings.substring(#authentication.principal.username, 0, 1)}">T</span>
-                <span class="current-user-name" th:text="${#authentication.principal.username}">テスト 太郎</span>
-                <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-                    <path d="m7 10 5 5 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                </svg>
-            </div>
-            <button type="button" class="primary-action-button" onclick="openCreateUserModal(event)">
-                <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-                    <path d="M12 5v14M5 12h14" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                </svg>
-                <span>ユーザを追加</span>
-            </button>
-        </div>
-    </header>
+        <button type="button" class="primary-action-button" onclick="openCreateUserModal(event)">
+            <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+                <path d="M12 5v14M5 12h14" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+            </svg>
+            <span>ユーザを追加</span>
+        </button>
+    </section>
 
     <section class="user-filter-panel" aria-label="ユーザ検索">
         <label class="search-control" for="userSearch">

--- a/src/test/java/jp/co/solxyz/jsn/springbootadvincedexam/app/admin/user/controller/UserManagementTemplateTest.java
+++ b/src/test/java/jp/co/solxyz/jsn/springbootadvincedexam/app/admin/user/controller/UserManagementTemplateTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
@@ -88,6 +89,7 @@ class UserManagementTemplateTest {
         requireElement(document, ".user-modal-close[aria-label='閉じる']");
         requireElement(document, ".copy-id-button[aria-label='ユーザIDをコピー']");
         requireElement(document, ".user-management-main");
+        assertThat(document.selectFirst(".current-user"), nullValue());
 
         assertThat(document.text(), containsString("ユーザを追加"));
         assertThat(document.text(), containsString("admin@solxyz.co.jp"));


### PR DESCRIPTION
## Summary
- Remove the user-name header nav shown only on the user management screen
- Align the user management header spacing, title, and add button with the book management screen
- Add a template assertion that the removed current-user block is not rendered

## Validation
- ./gradlew test --tests jp.co.solxyz.jsn.springbootadvincedexam.app.admin.user.controller.UserManagementTemplateTest