### PR TITLE
[codex] Fix deprecated Logback rolling policy

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -14,13 +14,11 @@
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <!-- ログファイルの設定 -->
         <file>logs/app.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <!-- ログファイルのローテーションの設定 -->
             <fileNamePattern>logs/archived/app.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
             <maxHistory>30</maxHistory>
-            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
-                <maxFileSize>10MB</maxFileSize>
-            </timeBasedFileNamingAndTriggeringPolicy>
         </rollingPolicy>
         <!-- ログの出力フォーマットを設定 -->
         <encoder>


### PR DESCRIPTION
## Summary
- Updated Logback rolling policy configuration to use SizeAndTimeBasedRollingPolicy.
- Kept daily rotation, 10MB rollover size, and 30-day retention unchanged.

## Why
Spring Boot startup emitted Logback warnings because SizeAndTimeBasedFNATP is deprecated when used directly.

## Validation
- ./gradlew test
- ./gradlew bootRun --args='--spring.main.web-application-type=none'